### PR TITLE
getMentorList new server migration

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import { MainPage } from '@/components';
+import { mentorUrl } from '@/libs';
 import type { WorkerType } from '@/types';
 
 import type { Metadata } from 'next';
@@ -19,7 +20,7 @@ export default async function Home() {
 }
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://gsm.moip.shop'),
+  metadataBase: new URL('https://www.gsm-networking.com'),
   title: '취업자 리스트 조회',
   description:
     '광주소프트웨어마이스터고등학교 학생들의 취업 정보를 확인 할 수 있어요.',
@@ -31,17 +32,15 @@ export const metadata: Metadata = {
 };
 
 const getWorkerList = async (): Promise<WorkerType[]> => {
-  const cookieStore = cookies();
-
-  const accessToken = cookieStore.get('accessToken')?.value;
-
   try {
+    const accessToken = cookies().get('accessToken');
+
     const response = await fetch(
-      new URL('/api/worker/list', process.env.API_BASE_URL),
+      new URL(`/api/v1${mentorUrl.getMentorList()}`, process.env.BASE_URL),
       {
         method: 'GET',
         headers: {
-          Authorization: `Bearer ${accessToken}`,
+          Cookie: `accessToken=${accessToken?.value}`,
         },
       }
     );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import type { Metadata } from 'next';
 const BASE_URL = process.env.BASE_URL;
 
 export default async function Home() {
-  const workerList = await getWorkerList();
+  const workerList = await getMentorList();
 
   const sortedWorkerList = [...workerList].sort((a, b) =>
     a.position.localeCompare(b.position)
@@ -31,7 +31,7 @@ export const metadata: Metadata = {
   },
 };
 
-const getWorkerList = async (): Promise<WorkerType[]> => {
+const getMentorList = async (): Promise<WorkerType[]> => {
   try {
     const accessToken = cookies().get('accessToken');
 
@@ -49,16 +49,16 @@ const getWorkerList = async (): Promise<WorkerType[]> => {
       throw new Error('accessToken이 만료되었습니다.');
     }
 
-    const workerList = await response.json();
+    const mentorList = await response.json();
 
-    return addTemporaryImgNumber(workerList);
+    return addTemporaryImgNumber(mentorList);
   } catch (error) {
     return redirect(`${BASE_URL}/auth/refresh`);
   }
 };
 
-const addTemporaryImgNumber = (workerList: WorkerType[]) =>
-  workerList.map((worker) => ({
+const addTemporaryImgNumber = (mentorList: WorkerType[]) =>
+  mentorList.map((worker) => ({
     ...worker,
     temporaryImgNumber: Math.floor(Math.random() * 5),
   }));

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,15 +32,18 @@ export const metadata: Metadata = {
 };
 
 const getMentorList = async (): Promise<WorkerType[]> => {
-  try {
-    const accessToken = cookies().get('accessToken');
+  const accessToken = cookies().get('accessToken')?.value;
 
+  // TODO refresh
+  // if(!accessToken)
+
+  try {
     const response = await fetch(
       new URL(`/api/v1${mentorUrl.getMentorList()}`, process.env.BASE_URL),
       {
         method: 'GET',
         headers: {
-          Cookie: `accessToken=${accessToken?.value}`,
+          Cookie: `accessToken=${accessToken}`,
         },
       }
     );

--- a/src/hooks/api/index.ts
+++ b/src/hooks/api/index.ts
@@ -1,4 +1,4 @@
-export * from './auth';
-export * from './file';
-export * from './mentee';
+// export * from './auth';
+// export * from './file';
+// export * from './mentee';
 export * from './mentor';

--- a/src/libs/api/requestUrlController.ts
+++ b/src/libs/api/requestUrlController.ts
@@ -14,5 +14,5 @@ export const menteeUrl = {
 
 export const mentorUrl = {
   postCreateMentor: () => '/mentor',
-  getMentorList: () => '/mentor/list',
+  getMentorList: () => '/mentor',
 };


### PR DESCRIPTION
## 개요 💡

멘토 가져오기 api를 신서버로 전환했습니다.

## 작업내용 ⌨️

- getMentorList api 신서버 전환
- mainpage Worker => Mentor 키워드 업데이트
  - 모든 Worker 키워드를 한번에 Mentor로 전환하기에는 다른 작업 중인 부분들에 미칠 side effect가 크다고 판단되어 점진적으로 업데이트 하겠습니다.
