### PR TITLE
Add usePostMentorRegister

### DIFF
--- a/src/hooks/api/mentor/usePostMentorRegister.ts
+++ b/src/hooks/api/mentor/usePostMentorRegister.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { mentorQueryKeys, mentorUrl, post } from '@/libs';
+import type { MentorType } from '@/types';
+
+import type { UseMutationOptions } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+
+export const usePostMentorRegister = (
+  options?: UseMutationOptions<unknown, AxiosError, MentorType, unknown>
+) =>
+  useMutation({
+    mutationKey: mentorQueryKeys.postMentorRegister(),
+    mutationFn: (mentorInfo: MentorType) =>
+      post(mentorUrl.postMentorRegister(), mentorInfo),
+    ...options,
+  });

--- a/src/libs/api/queryKeys.ts
+++ b/src/libs/api/queryKeys.ts
@@ -7,6 +7,6 @@ export const menteeQueryKeys = {
 } as const;
 
 export const mentorQueryKeys = {
-  postCreateMentor: () => ['mentor'],
+  postMentorRegister: () => ['mentor'],
   getMentorList: () => ['mentor', 'list'],
 } as const;

--- a/src/libs/api/requestUrlController.ts
+++ b/src/libs/api/requestUrlController.ts
@@ -13,6 +13,6 @@ export const menteeUrl = {
 };
 
 export const mentorUrl = {
-  postCreateMentor: () => '/mentor',
+  postMentorRegister: () => '/mentor',
   getMentorList: () => '/mentor',
 };

--- a/src/types/career.ts
+++ b/src/types/career.ts
@@ -1,0 +1,8 @@
+export interface CareerType {
+  companyName: string;
+  companyUrl?: string | null;
+  position: string;
+  startDate: Date;
+  endDate: Date | null;
+  isWorking: boolean;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,6 @@
 export * from './auth';
+export * from './career';
 export * from './generation';
+export * from './mentor';
 export * from './position';
 export * from './worker';

--- a/src/types/mentor.ts
+++ b/src/types/mentor.ts
@@ -1,0 +1,11 @@
+import type { CareerType } from '@/types';
+
+export interface MentorType {
+  name: string;
+  email: string;
+  generation: number;
+  phoneNumber: string;
+  snsUrl?: string | null;
+  profileUrl?: string | null;
+  career: CareerType[];
+}


### PR DESCRIPTION
## 개요 💡

멘토 등록을 위한 react query hook을 제작했습니다.

## 작업내용 ⌨️

- usePostMentorRegister 제작
- postCreateMentor -> postMentorRegister 용어 변경
- MentorType 추가
- CareerType 추가