### PR TITLE
Add FormItemWrapper

### DIFF
--- a/src/components/FormItemWrapper/index.stories.tsx
+++ b/src/components/FormItemWrapper/index.stories.tsx
@@ -1,0 +1,31 @@
+import FormItemWrapper from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof FormItemWrapper> = {
+  component: FormItemWrapper,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    title: 'Title',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FormItemWrapper>;
+
+export const Primary: Story = {};
+
+export const IsError: Story = {
+  args: {
+    errorMessage: 'Error Message',
+  },
+};
+
+export const IsRequired: Story = {
+  args: {
+    required: true,
+  },
+};

--- a/src/components/FormItemWrapper/index.tsx
+++ b/src/components/FormItemWrapper/index.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import * as S from './style';
+
+interface Props {
+  title: string;
+  required?: boolean;
+  errorMessage?: string | null;
+  children: React.ReactNode;
+}
+
+const FormItemWrapper: React.FC<Props> = ({
+  title,
+  required,
+  errorMessage,
+  children,
+}) => (
+  <S.Container>
+    <S.Title>
+      {title}
+      {required && <S.Required>*</S.Required>}
+    </S.Title>
+    {children}
+    <S.ErrorMessage>{errorMessage}</S.ErrorMessage>
+  </S.Container>
+);
+
+export default FormItemWrapper;

--- a/src/components/FormItemWrapper/style.ts
+++ b/src/components/FormItemWrapper/style.ts
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+export const Title = styled.p`
+  display: inline;
+  ${({ theme }) => theme.typo.body2}
+  color: ${({ theme }) => theme.color.grey[600]};
+`;
+
+export const Required = styled.span`
+  color: ${({ theme }) => theme.color.error};
+`;
+
+export const ErrorMessage = styled.p`
+  height: 1.125rem;
+  ${({ theme }) => theme.typo.caption}
+  color: ${({ theme }) => theme.color.error};
+`;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@ export * from './Buttons';
 export * from './Modal';
 export { default as DropDown } from './DropDown';
 export { default as FilterButton } from './Buttons/Filter';
+export { default as FormItemWrapper } from './FormItemWrapper';
 export { default as Header } from './Header';
 export { default as InfoSearch } from './InfoSearch';
 export { default as Layout } from './Layout';


### PR DESCRIPTION
## 개요 💡

FormItemWrapper를 제작하였습니다.

## 작업내용 ⌨️

멘토 등록 폼에 사용 될, FormItemWrapper를 제작했습니다.

input이나 select 같은 form item들의 공통 부분을 FormItemWrapper으로 작성해두어 재사용성을 높입니다.

storybook
http://localhost:6006/?path=/story/components-formitemwrapper--primary

을 통해 확인 가능하십니다.