### PR TITLE
Add UTCDate

### DIFF
--- a/src/utils/UTCDate.ts
+++ b/src/utils/UTCDate.ts
@@ -1,0 +1,12 @@
+/**
+ * 환경(e.g. 브라우저의 시간대)에 구애받지 않는 UTC Date 객체를 반환합니다.
+ *
+ * @param year - 년
+ * @param month - 월 (0 ~ 11) - Date 객체의 표준 따름
+ * @param date - 일 - default = 1
+ * @returns Date 객체
+ */
+const UTCDate = (year: number, month: number, date: number = 1) =>
+  new Date(Date.UTC(year, month, date));
+
+export default UTCDate;

--- a/src/utils/__test__/UTCDate.test.ts
+++ b/src/utils/__test__/UTCDate.test.ts
@@ -1,0 +1,19 @@
+import { UTCDate } from '@/utils';
+
+describe('UTCDate', () => {
+  test('다른 환경에 구애 받지 않는 UTC Date 객체를 반환합니다.', () => {
+    const YEAR = 2023;
+    const MONTH = 3;
+    const expectUTCDate = new Date(Date.UTC(YEAR, MONTH));
+
+    expect(UTCDate(YEAR, MONTH)).toEqual(expectUTCDate);
+  });
+
+  test('단순 생성 Date 객체는 환경에 영향을 받습니다.', () => {
+    const YEAR = 2023;
+    const MONTH = 3;
+    const expectNormalDate = new Date(YEAR, MONTH);
+
+    expect(UTCDate(YEAR, MONTH)).not.toEqual(expectNormalDate);
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export { default as UTCDate } from './UTCDate';
 export { default as extractSubstring } from './extractSubstring';
 export { default as isNumeric } from './isNumeric';
 export { default as minutesToSeconds } from './minutesToSeconds';


### PR DESCRIPTION
## 개요 💡

UTCDate util을 추가했습니다

## 작업내용 ⌨️

Date 객체를 api 요청에 담아 보내게 되면 아래 사진과 같이,

<img width="600" alt="스크린샷 2023-11-12 00 03 33" src="https://github.com/themoment-team/GSM-Networking-front/assets/80103328/220c8ce8-7de5-4f81-a7ec-232639d2bfb2">

UTC로 변환되어 전송이 되어 예상치 못한 혼동이 생길 수 있습니다.

따라서 환경에 구애받지 않는 UTC 형식의 Date 객체를 생성하는 util을 사용하여
재직년월 등록 시 발생할 수 있는 혼동을 막도록 하겠습니다
