### PR TITLE
Add iOS compatible & input placeholder

### DIFF
--- a/src/components/CareerRegistrationBox/index.tsx
+++ b/src/components/CareerRegistrationBox/index.tsx
@@ -149,6 +149,7 @@ const CareerRegistrationBox: React.FC<Props> = ({
         <InputFormItem
           value={companyName.value}
           inputTitle='회사명'
+          placeholder='회사명을 입력해주세요.'
           required
           onChange={(e) => handleInputChange(e, 'companyName')}
           errorMessage={companyName.errorMessage}
@@ -156,6 +157,7 @@ const CareerRegistrationBox: React.FC<Props> = ({
         <InputFormItem
           value={companyUrl.value}
           inputTitle='회사 URL'
+          placeholder='회사 URL을 입력해주세요.'
           onChange={(e) => handleInputChange(e, 'companyUrl')}
           errorMessage={companyUrl.errorMessage}
         />

--- a/src/components/FormItem/Input/style.ts
+++ b/src/components/FormItem/Input/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const CustomInput = styled.input<{ isError: boolean }>`
-  ${({ theme }) => theme.typo.body1}
+  ${({ theme }) => theme.typo.body1};
   color: ${({ theme }) => theme.color.black};
   padding: 0.75rem 1rem;
   border: 0.0625rem solid
@@ -10,6 +10,7 @@ export const CustomInput = styled.input<{ isError: boolean }>`
   border-radius: 0.625rem;
 
   ::placeholder {
+    ${({ theme }) => theme.typo.body1};
     color: ${({ theme }) => theme.color.grey[400]};
   }
 

--- a/src/components/InfoSearch/style.ts
+++ b/src/components/InfoSearch/style.ts
@@ -49,6 +49,7 @@ export const SearchInput = styled.input`
   padding: 0.75rem 1rem;
   background-color: ${({ theme }) => theme.color.white};
   &::placeholder {
+    ${({ theme }) => theme.typo.body1};
     color: ${({ theme }) => theme.color.grey[400]};
   }
 `;

--- a/src/components/Select/style.ts
+++ b/src/components/Select/style.ts
@@ -6,6 +6,7 @@ export const CustomSelect = styled.select<{
 }>`
   ${({ theme }) => theme.typo.body1}
   width: 100%;
+  height: 3rem;
   color: ${({ theme, isDefault }) =>
     isDefault ? theme.color.grey[400] : theme.color.black};
   padding: 0.75rem 1rem;
@@ -13,6 +14,7 @@ export const CustomSelect = styled.select<{
     ${({ theme, isError }) =>
       isError ? theme.color.error : theme.color.grey[100]};
   border-radius: 0.625rem;
+  background: ${({ theme }) => theme.color.white};
   cursor: pointer;
 
   :disabled {

--- a/src/pageContainer/register/mentor/index.tsx
+++ b/src/pageContainer/register/mentor/index.tsx
@@ -141,33 +141,37 @@ const MentorRegister: React.FC<Props> = ({ tempMentorId, mentorInfo }) => {
             <InputFormItem
               {...register('name')}
               inputTitle='이름'
+              placeholder='이름을 입력해주세요.'
               errorMessage={errors.name?.message}
               required={true}
             />
             <InputFormItem
               {...register('phoneNumber')}
               inputTitle='전화번호'
+              placeholder='전화번호를 입력해주세요.'
               errorMessage={errors.phoneNumber?.message}
               required={true}
             />
             <InputFormItem
               {...register('email')}
               inputTitle='이메일'
+              placeholder='이메일을 입력해주세요.'
               errorMessage={errors.email?.message}
               required={true}
             />
             <InputFormItem
               {...register('snsUrl')}
               inputTitle='SNS'
+              placeholder='SNS 주소를 입력해주세요.'
               errorMessage={errors.snsUrl?.message}
             />
             <SelectFormItem
               {...register('generation')}
-              required={true}
               selectTitle='기수'
               options={[...GENERATION_ARRAY]}
               defaultValue='기수를 선택해주세요.'
               errorMessage={errors.generation?.message}
+              required={true}
             />
           </S.InputWrapper>
         </S.PrivacyBox>

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -76,6 +76,12 @@ export function GlobalStyle() {
           background: inherit;
           cursor: pointer;
         }
+
+        input {
+          @media (max-width: 600px) {
+            font-size: 16px !important;
+          }
+        }
       `}
     />
   );


### PR DESCRIPTION
## 개요 💡

iOS 대응 및 input의 placeholder를 추가했습니다.

## 작업내용 ⌨️

- globalstyle에서 input 모바일 시, 16px로 font size를 지정했습니다.
  - iOS에서 input의 font size가 16px 미만일 시, input이 focus 되면 확대가 되는 현상이 있어 해결했습니다.
- input들의 누락된 placeholder를 추가했습니다.
- input들의 누락된 placeholder의 typo를 추가했습니다.
