### PR TITLE
[Hotfix] Update main fetching error handling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,27 +30,31 @@ const getMentorList = async (): Promise<WorkerType[]> => {
 
   if (!accessToken) return redirect('/auth/refresh');
 
-  try {
-    const response = await fetch(
-      new URL(`/api/v1${mentorUrl.getMentorList()}`, process.env.BASE_URL),
-      {
-        method: 'GET',
-        headers: {
-          Cookie: `accessToken=${accessToken}`,
-        },
-      }
-    );
-
-    if (!response.ok) {
-      throw new Error('accessToken이 만료되었습니다.');
+  const response = await fetch(
+    new URL(`/api/v1${mentorUrl.getMentorList()}`, process.env.BASE_URL),
+    {
+      method: 'GET',
+      headers: {
+        Cookie: `accessToken=${accessToken}`,
+      },
     }
+  );
 
-    const mentorList = await response.json();
+  if (response.status === 403) {
+    return redirect('/auth/signup');
+  }
 
-    return addTemporaryImgNumber(mentorList);
-  } catch (error) {
+  if (response.status === 401) {
     return redirect('/auth/refresh');
   }
+
+  if (!response.ok) {
+    return redirect('/auth/signin');
+  }
+
+  const mentorList = await response.json();
+
+  return addTemporaryImgNumber(mentorList);
 };
 
 const addTemporaryImgNumber = (mentorList: WorkerType[]) =>


### PR DESCRIPTION
## 개요 💡

main 페이지의 server side fetching에서의 error handling 방식을 업데이트 했습니다.

## 작업내용 ⌨️

- try...catch 문으로 인해 next/navigation redirect를 사용하기 쉽지 않아 try...catch를 제거 했습니다
  - try 내부에서 next/navigation redirect 사용 시, 내부적으로 error를 발생시켜 catch 문이 동작하는 현상이 존재합니다.
  - https://stackoverflow.com/questions/76191324/next-13-4-error-next-redirect-in-api-routes
  - https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/redirect.ts#L16-L41C2
  
### status에 따른 redirect

- 401 - /auth/refresh
- 403 - /auth/signup
- 이 외 - /auth/signin