### PR TITLE
[Hotfix] Update signup agreement box

### DIFF
--- a/src/pageContainer/signup/index.tsx
+++ b/src/pageContainer/signup/index.tsx
@@ -55,13 +55,18 @@ const SignUp = () => {
           >
             {checkPolicy && <CheckBoxIcon />}
           </S.AgreementButton>
-          <S.AgreementButtonLink
+          <S.AgreementTextButton
+            onClick={() => setCheckPolicy((prev) => !prev)}
+          >
+            개인정보 처리방침
+          </S.AgreementTextButton>
+          <S.AgreementLink
             href={PRIVACY_POLICY_URL}
             target='_blank'
             rel='noopener noreferrer'
           >
-            개인정보 처리방침
-          </S.AgreementButtonLink>
+            본문 확인
+          </S.AgreementLink>
         </S.AgreementButtonBox>
       </S.AgreementBox>
       <S.SubmitButton disabled={role === null} onClick={handleNextButtonClick}>

--- a/src/pageContainer/signup/style.ts
+++ b/src/pageContainer/signup/style.ts
@@ -57,9 +57,14 @@ export const AgreementButton = styled.button<{ checkPolicy: boolean }>`
   }
 `;
 
-export const AgreementButtonLink = styled.a`
+export const AgreementTextButton = styled.button`
   ${({ theme }) => theme.typo.body2};
   color: ${({ theme }) => theme.color.grey[500]};
+`;
+
+export const AgreementLink = styled.a`
+  ${({ theme }) => theme.typo.body2};
+  color: ${({ theme }) => theme.color.skyBlue[300]};
 `;
 
 export const SubmitButton = styled.button`


### PR DESCRIPTION
## 개요 💡

개인정보 처리방침 본문 확인 링크를 별도로 분리했습니다.

## 작업내용 ⌨️

- 개인정보 처리방침 본문 확인 링크 별도 분리

### 전

기존 방식의 문제점

- 개인정보 처리방침 텍스트가 라벨의 역할을 하는 것 처럼 보여 유저들이 체크를 하기 위해 누르는 경우가 있다.
- 모바일에서 잘 못 클릭되어 해당 페이지로 이동되는 경우가 많다.

<img width="617" alt="스크린샷 2023-11-17 08 22 52" src="https://github.com/themoment-team/GSM-Networking-front/assets/80103328/bd0495ac-c97a-4b2b-8fe9-49d9b201cf9b">

### 후

위의 문제점을 개선하고자 분리합니다

- 개인정보 처리방침 텍스트는 이제, label의 역할을 하여 체크를 위해 사용됩니다.
- 본문 확인을 누르면 약관 페이지로 이동합니다

<img width="621" alt="스크린샷 2023-11-17 08 22 57" src="https://github.com/themoment-team/GSM-Networking-front/assets/80103328/d719af19-7a0f-4fd9-bd6a-4a90614c0ed7">