### PR TITLE
Add profile image register api

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,21 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'gsm-networking-bucket.s3.ap-northeast-2.amazonaws.com',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'bucket.gsm-networking.com',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
   rewrites: async () => [
     {
       source: '/api/v1/:path*',

--- a/src/components/Buttons/ProfileUpdate/index.tsx
+++ b/src/components/Buttons/ProfileUpdate/index.tsx
@@ -5,7 +5,7 @@ import * as S from './style';
 import { PenIcon } from '@/assets';
 
 interface Props {
-  onClick: () => void;
+  onClick?: () => void;
 }
 
 const ProfileUpdateButton: React.FC<Props> = ({ onClick }) => (

--- a/src/components/Buttons/ProfileUpdate/index.tsx
+++ b/src/components/Buttons/ProfileUpdate/index.tsx
@@ -11,7 +11,8 @@ interface Props {
 const ProfileUpdateButton: React.FC<Props> = ({ onClick }) => (
   <S.Button type='button' onClick={onClick}>
     <PenIcon />
-    프로필 수정
+    이미지 등록
+    {/* 프로필 수정 // 임시로 이미지 등록으로 내용 변경해두겠습니다. */}
   </S.Button>
 );
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 
+import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
 import { toast } from 'react-toastify';
@@ -44,7 +45,11 @@ const Header: React.FC<Props> = ({ clearList }) => {
             )}
           </S.RedirectBox>
           <S.ProfileBox type='button' onClick={handleProfileClick}>
-            <I.PersonImg4 />
+            {data?.profileUrl ? (
+              <Image src={data.profileUrl} alt='profile img' fill />
+            ) : (
+              <I.PersonImg4 />
+            )}
           </S.ProfileBox>
         </S.RightBox>
       </S.Inner>

--- a/src/components/Header/style.ts
+++ b/src/components/Header/style.ts
@@ -70,6 +70,11 @@ export const ProfileBox = styled.button`
   overflow: hidden;
   width: 2.25rem;
   height: 2.25rem;
+  position: relative;
+
+  & > img {
+    object-fit: cover;
+  }
 
   & > svg {
     width: 2.1875rem;

--- a/src/components/MentorCard/index.stories.tsx
+++ b/src/components/MentorCard/index.stories.tsx
@@ -28,6 +28,8 @@ export const Primary: Story = {
         URL: 'https://official.hellogsm.kr/',
       },
       temporaryImgNumber: 0,
+      profileUrl:
+        'https://gsm-networking-bucket.s3.ap-northeast-2.amazonaws.com/a6c46a31-485e-4cc4-b9ad-e572eee14f622023-11-21T09%3A16%3A21.446456989.jpeg',
     },
   },
 };

--- a/src/components/MentorCard/index.tsx
+++ b/src/components/MentorCard/index.tsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import Image from 'next/image';
+
 import { toast } from 'react-toastify';
 
 import RandomWorkerImg from './RandomMentorImg';
@@ -34,7 +36,11 @@ const MentorCard: React.FC<Props> = ({ worker }) => {
   return (
     <S.WorkerCardContainer>
       <S.WorkerImgBox>
-        <RandomWorkerImg temporaryImgNumber={worker.temporaryImgNumber} />
+        {worker.profileUrl ? (
+          <Image src={worker.profileUrl} alt={worker.name} fill />
+        ) : (
+          <RandomWorkerImg temporaryImgNumber={worker.temporaryImgNumber} />
+        )}
       </S.WorkerImgBox>
       <S.WorkerInfoHead>
         <S.WorkerNameBox>

--- a/src/components/MentorCard/style.ts
+++ b/src/components/MentorCard/style.ts
@@ -94,6 +94,13 @@ export const WorkerImgBox = styled.div`
   align-items: end;
   width: 100%;
   height: 6.8125rem;
+  position: relative;
+  overflow: hidden;
+  border: 0.0625rem solid ${({ theme }) => theme.color.grey[50]};
+
+  & > img {
+    object-fit: contain;
+  }
 `;
 
 export const BlueCheckIconWrapper = styled.div`

--- a/src/components/Modal/MyPage/ModalWrapper/index.tsx
+++ b/src/components/Modal/MyPage/ModalWrapper/index.tsx
@@ -18,19 +18,12 @@ const MyPageModalWrapper: React.FC<Props> = ({
   children,
   closeModal,
   innerCss,
-}) => {
-  const handleModalWrapperClick = (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>
-  ) => {
-    closeModal();
-    e.stopPropagation();
-  };
-
-  return (
-    <S.ModalWrapper onClick={handleModalWrapperClick}>
-      <S.ModalInner css={innerCss}>{children}</S.ModalInner>
-    </S.ModalWrapper>
-  );
-};
+}) => (
+  <S.ModalWrapper onClick={closeModal}>
+    <S.ModalInner onClick={(e) => e.stopPropagation()} css={innerCss}>
+      {children}
+    </S.ModalInner>
+  </S.ModalWrapper>
+);
 
 export default MyPageModalWrapper;

--- a/src/components/Modal/MyPage/ModalWrapper/style.ts
+++ b/src/components/Modal/MyPage/ModalWrapper/style.ts
@@ -4,6 +4,9 @@ export const ModalWrapper = styled.div`
   width: 100vw;
   height: 100vh;
   height: 100dvh;
+  position: absolute;
+  top: 0;
+  left: 0;
   background-color: rgba(0, 0, 0, 0.15);
   display: flex;
   justify-content: center;

--- a/src/components/Modal/MyPage/ModalWrapper/style.ts
+++ b/src/components/Modal/MyPage/ModalWrapper/style.ts
@@ -11,6 +11,7 @@ export const ModalWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: 10;
 `;
 
 export const ModalInner = styled.div`

--- a/src/components/Modal/MyPage/ProfileImgRegister/index.tsx
+++ b/src/components/Modal/MyPage/ProfileImgRegister/index.tsx
@@ -2,29 +2,74 @@
 
 import { css } from '@emotion/react';
 
+import { toast } from 'react-toastify';
+
 import * as S from './style';
 
 import { ImageRegisterIcon } from '@/assets';
 import { MyPageModalWrapper } from '@/components';
+import { usePostProfileImgUrl } from '@/hooks';
+import { usePostUploadFile } from '@/hooks';
 
 interface Props {
   closeModal: () => void;
 }
 
-const ProfileImgRegisterModal: React.FC<Props> = () => (
-  <MyPageModalWrapper
-    closeModal={() => {}}
-    innerCss={css`
-      border-radius: 1.25rem;
-      padding: 1.5rem;
-    `}
-  >
-    <S.Title>프로필 이미지 변경</S.Title>
-    <S.ImgInput type='file' id='img-input' accept='image/*' />
-    <S.ImgInputLabel htmlFor='img-input'>
-      <ImageRegisterIcon />
-    </S.ImgInputLabel>
-  </MyPageModalWrapper>
-);
+const ProfileImgRegisterModal: React.FC<Props> = ({ closeModal }) => {
+  const { mutate: mutateUploadFile } = usePostUploadFile();
+  const { mutate: mutateProfileImgUrl } = usePostProfileImgUrl();
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
+
+    const profileImg = e.target.files[0];
+
+    if (profileImg.size > 1024 * 1024 * 20) {
+      return toast.error('프로필 이미지는 20MB 이하만 업로드 가능합니다.');
+    }
+
+    const formData = new FormData();
+
+    formData.append('file', profileImg);
+
+    mutateUploadFile(formData, {
+      onSuccess: ({ fileUrl }) => {
+        mutateProfileImgUrl(fileUrl, {
+          onSuccess: () => {
+            toast.success('프로필 이미지 업로드에 성공했습니다.');
+            closeModal();
+          },
+          onError: () => {
+            toast.error('프로필 이미지 업로드에 실패했습니다.');
+          },
+        });
+      },
+      onError: () => {
+        toast.error('프로필 이미지 업로드에 실패했습니다.');
+      },
+    });
+  };
+
+  return (
+    <MyPageModalWrapper
+      closeModal={closeModal}
+      innerCss={css`
+        border-radius: 1.25rem;
+        padding: 1.5rem;
+      `}
+    >
+      <S.Title>프로필 이미지 변경</S.Title>
+      <S.ImgInput
+        type='file'
+        id='img-input'
+        accept='image/*'
+        onChange={handleFileInputChange}
+      />
+      <S.ImgInputLabel htmlFor='img-input'>
+        <ImageRegisterIcon />
+      </S.ImgInputLabel>
+    </MyPageModalWrapper>
+  );
+};
 
 export default ProfileImgRegisterModal;

--- a/src/components/Modal/MyPage/ProfileImgRegister/index.tsx
+++ b/src/components/Modal/MyPage/ProfileImgRegister/index.tsx
@@ -8,8 +8,9 @@ import * as S from './style';
 
 import { ImageRegisterIcon } from '@/assets';
 import { MyPageModalWrapper } from '@/components';
-import { usePostProfileImgUrl } from '@/hooks';
+import { useGetMyInfo, usePostProfileImgUrl } from '@/hooks';
 import { usePostUploadFile } from '@/hooks';
+import type { PostProfileImgType } from '@/types';
 
 interface Props {
   closeModal: () => void;
@@ -18,6 +19,7 @@ interface Props {
 const ProfileImgRegisterModal: React.FC<Props> = ({ closeModal }) => {
   const { mutate: mutateUploadFile } = usePostUploadFile();
   const { mutate: mutateProfileImgUrl } = usePostProfileImgUrl();
+  const { refetch: refetchGetMyInfo } = useGetMyInfo();
 
   const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;
@@ -34,9 +36,14 @@ const ProfileImgRegisterModal: React.FC<Props> = ({ closeModal }) => {
 
     mutateUploadFile(formData, {
       onSuccess: ({ fileUrl }) => {
-        mutateProfileImgUrl(fileUrl, {
+        const data: PostProfileImgType = {
+          profileUrl: fileUrl,
+        };
+
+        mutateProfileImgUrl(data, {
           onSuccess: () => {
             toast.success('프로필 이미지 업로드에 성공했습니다.');
+            refetchGetMyInfo();
             closeModal();
           },
           onError: () => {

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -1,15 +1,27 @@
 'use client';
 
+import Image from 'next/image';
+
 import * as S from './style';
 
-import { RandomMentorImg /*ProfileUpdateButton*/ } from '@/components';
+import {
+  ProfileUpdateButton,
+  RandomMentorImg /*ProfileUpdateButton*/,
+} from '@/components';
 
 interface Props {
   name: string;
   generation: number;
+  profileUrl?: string;
+  profileRegisterModalOpen?: () => void;
 }
 
-const Profile: React.FC<Props> = ({ name, generation }) => {
+const Profile: React.FC<Props> = ({
+  name,
+  generation,
+  profileUrl,
+  profileRegisterModalOpen,
+}) => {
   // TODO : server side 와 마크업을 일치시키기 위한 로직 변경 필요.
   const randomValue = Math.floor(Math.random() * 5); //0부터 4까지 중의 랜덤값 생성
 
@@ -18,13 +30,17 @@ const Profile: React.FC<Props> = ({ name, generation }) => {
   return (
     <S.ProfileWrapper>
       <S.ProfileImageBox>
-        <RandomMentorImg temporaryImgNumber={randomValue} />
+        {profileUrl ? (
+          <Image src={profileUrl} alt='profile img' fill />
+        ) : (
+          <RandomMentorImg temporaryImgNumber={randomValue} />
+        )}
       </S.ProfileImageBox>
       <S.ProfileInfo>
         <S.UserName>
           {generation}기 {name}
         </S.UserName>
-        {/* <ProfileUpdateButton onClick={handleClick} /> */}
+        <ProfileUpdateButton onClick={profileRegisterModalOpen} />
       </S.ProfileInfo>
     </S.ProfileWrapper>
   );

--- a/src/components/Profile/style.ts
+++ b/src/components/Profile/style.ts
@@ -12,6 +12,11 @@ export const ProfileImageBox = styled.div`
   width: 6rem;
   height: 6rem;
   padding: 0.8rem 0 0 0.3rem;
+  position: relative;
+
+  & > img {
+    object-fit: cover;
+  }
 
   svg {
     width: 5.8rem;

--- a/src/components/TempMentorCard/index.stories.tsx
+++ b/src/components/TempMentorCard/index.stories.tsx
@@ -25,6 +25,8 @@ export const Primary: Story = {
         URL: 'https://official.hellogsm.kr/',
       },
       temporaryImgNumber: 0,
+      profileUrl:
+        'https://gsm-networking-bucket.s3.ap-northeast-2.amazonaws.com/a6c46a31-485e-4cc4-b9ad-e572eee14f622023-11-21T09%3A16%3A21.446456989.jpeg',
     },
   },
 };

--- a/src/hooks/api/file/index.ts
+++ b/src/hooks/api/file/index.ts
@@ -1,0 +1,1 @@
+export * from './usePostUploadFile';

--- a/src/hooks/api/file/usePostUploadFile.ts
+++ b/src/hooks/api/file/usePostUploadFile.ts
@@ -1,0 +1,22 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { fileQueryKeys, fileUrl, post } from '@/libs';
+
+import type { UseMutationOptions } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+
+interface ReturnDataType {
+  fileUrl: string;
+}
+
+export const usePostUploadFile = (
+  options?: UseMutationOptions<ReturnDataType, AxiosError, FormData>
+) =>
+  useMutation({
+    mutationKey: fileQueryKeys.postUploadFile(),
+    mutationFn: (data: FormData) =>
+      post<ReturnDataType>(fileUrl.postUploadFile(), data, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      }),
+    ...options,
+  });

--- a/src/hooks/api/index.ts
+++ b/src/hooks/api/index.ts
@@ -1,5 +1,5 @@
 // export * from './auth';
-// export * from './file';
+export * from './file';
 export * from './mentee';
 export * from './mentor';
 export * from './tempMentor';

--- a/src/hooks/api/index.ts
+++ b/src/hooks/api/index.ts
@@ -3,3 +3,4 @@
 export * from './mentee';
 export * from './mentor';
 export * from './tempMentor';
+export * from './user';

--- a/src/hooks/api/user/index.ts
+++ b/src/hooks/api/user/index.ts
@@ -1,0 +1,1 @@
+export * from './usePostProfileImgUrl';

--- a/src/hooks/api/user/usePostProfileImgUrl.ts
+++ b/src/hooks/api/user/usePostProfileImgUrl.ts
@@ -1,15 +1,17 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { post, userQueryKeys, userUrl } from '@/libs';
+import type { PostProfileImgType } from '@/types';
 
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 
 export const usePostProfileImgUrl = (
-  options?: UseMutationOptions<void, AxiosError, string>
+  options?: UseMutationOptions<void, AxiosError, PostProfileImgType>
 ) =>
   useMutation({
     mutationKey: userQueryKeys.postProfileImgUrl(),
-    mutationFn: (url: string) => post<void>(userUrl.postProfileImgUrl(url)),
+    mutationFn: (data: PostProfileImgType) =>
+      post<void>(userUrl.postProfileImgUrl(), data),
     ...options,
   });

--- a/src/hooks/api/user/usePostProfileImgUrl.ts
+++ b/src/hooks/api/user/usePostProfileImgUrl.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { post, userQueryKeys, userUrl } from '@/libs';
+
+import type { UseMutationOptions } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+
+export const usePostProfileImgUrl = (
+  options?: UseMutationOptions<void, AxiosError, string>
+) =>
+  useMutation({
+    mutationKey: userQueryKeys.postProfileImgUrl(),
+    mutationFn: (url: string) => post<void>(userUrl.postProfileImgUrl(url)),
+    ...options,
+  });

--- a/src/libs/api/queryKeys.ts
+++ b/src/libs/api/queryKeys.ts
@@ -1,5 +1,5 @@
 export const fileQueryKeys = {
-  postUploadImage: () => ['file'],
+  postUploadFile: () => ['file'],
 } as const;
 
 export const menteeQueryKeys = {
@@ -16,4 +16,8 @@ export const mentorQueryKeys = {
 export const tempMentorQueryKeys = {
   getSearchTempMentor: (keyword: string) => ['temp', 'mentor', keyword],
   deleteTempMentor: () => ['temp', 'mentor', 'delete'],
+};
+
+export const userQueryKeys = {
+  postProfileImgUrl: () => ['user', 'profile'],
 };

--- a/src/libs/api/requestUrlController.ts
+++ b/src/libs/api/requestUrlController.ts
@@ -5,7 +5,7 @@ export const authUrl = {
 };
 
 export const fileUrl = {
-  postUploadImage: () => '/file',
+  postUploadFile: () => '/file',
 };
 
 export const menteeUrl = {
@@ -23,4 +23,8 @@ export const tempMentorUrl = {
   getSearchTempMentor: (userName: string) => `/temp-mentor/search/${userName}`,
   getTempMentorInfo: (id: number) => `/temp-mentor/${id}`,
   deleteTempMentor: (id: number) => `/temp-mentor/${id}`,
+};
+
+export const userUrl = {
+  postProfileImgUrl: (url: string) => `/profile/${url}`,
 };

--- a/src/libs/api/requestUrlController.ts
+++ b/src/libs/api/requestUrlController.ts
@@ -26,5 +26,5 @@ export const tempMentorUrl = {
 };
 
 export const userUrl = {
-  postProfileImgUrl: (url: string) => `/profile/${url}`,
+  postProfileImgUrl: () => `/user/profile-url`,
 };

--- a/src/pageContainer/mypage/index.tsx
+++ b/src/pageContainer/mypage/index.tsx
@@ -1,8 +1,15 @@
 'use client';
 
+import { useState } from 'react';
+
 import * as S from './style';
 
-import { Profile, CareerCard, Header } from '@/components';
+import {
+  Profile,
+  CareerCard,
+  Header,
+  ProfileImgRegisterModal,
+} from '@/components';
 import type { CareerType } from '@/types';
 
 interface MentorInfoType {
@@ -22,22 +29,31 @@ interface Props {
 
 const MyPage: React.FC<Props> = ({
   myInfo: { name, generation, career: careerList },
-}) => (
-  <S.Container>
-    <Header />
-    <S.ProfileContainer>
-      <Profile name={name} generation={generation} />
-    </S.ProfileContainer>
-    <S.Line />
-    <S.CareerContainer>
-      <S.CareerInfoText>재직 정보</S.CareerInfoText>
-      <S.CareerBox>
-        {careerList.map((career, i) => (
-          <CareerCard career={career} key={i /*career.id 수정 */} />
-        ))}
-      </S.CareerBox>
-    </S.CareerContainer>
-    {/* <S.WithdrawContainer> 추후 기능 구현 시 사용
+}) => {
+  const [openModalCase, setOpenModalCase] = useState<
+    'close' | 'profileImgRegister' | 'signOut' | 'withdraw'
+  >('close');
+
+  return (
+    <>
+      {openModalCase === 'profileImgRegister' && (
+        <ProfileImgRegisterModal closeModal={() => setOpenModalCase('close')} />
+      )}
+      <S.Container>
+        <Header />
+        <S.ProfileContainer>
+          <Profile name={name} generation={generation} />
+        </S.ProfileContainer>
+        <S.Line />
+        <S.CareerContainer>
+          <S.CareerInfoText>재직 정보</S.CareerInfoText>
+          <S.CareerBox>
+            {careerList.map((career, i) => (
+              <CareerCard career={career} key={i /*career.id 수정 */} />
+            ))}
+          </S.CareerBox>
+        </S.CareerContainer>
+        {/* <S.WithdrawContainer> 추후 기능 구현 시 사용
       <S.WithdrawBox hoverColor='blue'>
         <ExitIcon />
         <S.WithdrawText>로그아웃</S.WithdrawText>
@@ -47,7 +63,9 @@ const MyPage: React.FC<Props> = ({
         <S.WithdrawText>회원탈퇴</S.WithdrawText>
       </S.WithdrawBox>
     </S.WithdrawContainer> */}
-  </S.Container>
-);
+      </S.Container>
+    </>
+  );
+};
 
 export default MyPage;

--- a/src/pageContainer/mypage/index.tsx
+++ b/src/pageContainer/mypage/index.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 
+import Image from 'next/image';
+
 import * as S from './style';
 
 import {
@@ -28,7 +30,7 @@ interface Props {
 }
 
 const MyPage: React.FC<Props> = ({
-  myInfo: { name, generation, career: careerList },
+  myInfo: { name, generation, career: careerList, profileUrl },
 }) => {
   const [openModalCase, setOpenModalCase] = useState<
     'close' | 'profileImgRegister' | 'signOut' | 'withdraw'
@@ -42,7 +44,11 @@ const MyPage: React.FC<Props> = ({
       <S.Container>
         <Header />
         <S.ProfileContainer>
-          <Profile name={name} generation={generation} />
+          {profileUrl ? (
+            <Image src={profileUrl} fill alt='profile image' />
+          ) : (
+            <Profile name={name} generation={generation} />
+          )}
         </S.ProfileContainer>
         <S.Line />
         <S.CareerContainer>

--- a/src/pageContainer/mypage/index.tsx
+++ b/src/pageContainer/mypage/index.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
 import { toast } from 'react-toastify';
@@ -44,11 +43,14 @@ const MyPage: React.FC = () => {
         {data && (
           <>
             <S.ProfileContainer>
-              {data.profileUrl ? (
-                <Image src={data.profileUrl} fill alt='profile img' />
-              ) : (
-                <Profile name={data.name} generation={data.generation} />
-              )}
+              <Profile
+                name={data.name}
+                generation={data.generation}
+                profileUrl={data.profileUrl}
+                profileRegisterModalOpen={() =>
+                  setOpenModalCase('profileImgRegister')
+                }
+              />
             </S.ProfileContainer>
             <S.Line />
             <S.CareerContainer>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,4 +5,5 @@ export * from './mentor';
 export * from './mentorInfo';
 export * from './mentorInfoForm';
 export * from './position';
+export * from './profile';
 export * from './worker';

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,3 @@
+export interface PostProfileImgType {
+  profileUrl: string;
+}

--- a/src/types/worker.ts
+++ b/src/types/worker.ts
@@ -15,4 +15,5 @@ export interface WorkerType {
   SNS: string;
   temporaryImgNumber: number;
   registered: boolean;
+  profileUrl: string | null;
 }


### PR DESCRIPTION
## 개요 💡

프로필 이미지 등록 api 연동 했습니다.

## 작업내용 ⌨️

- 외부 이미지 사용을 위한 next.config.js image 속성 추가
- profileUrl로 멘토 이미지 보여지도록 했습니다
  - Header
  - MentorCard
  - Profile
- 이미지를 업로드하는 usePostUploadFile 추가
- 이미지 url을 업로드하는 usePostProfileImgUrl 추가

### 핵심 로직

1. usePostUploadFile로 이미지를 업로드합니다.
2. 1의 응답으로 받은 fileUrl을 담아 usePostProfileImgUrl 이미지 url 등록 요청을 보냅니다.
3. useGetMyInfo의 refetch로 갱신된 내 정보 데이터를 다시 받아옵니다