### PR TITLE
Add gwangya page 

### DIFF
--- a/src/app/community/gwangya/page.tsx
+++ b/src/app/community/gwangya/page.tsx
@@ -1,0 +1,12 @@
+import { Gwangya } from '@/pageContainer';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '광야',
+  description: '익명으로 자유롭게 소통할 수 있는 광소마의 넓은 들판입니다.',
+};
+
+const GwangyaPage = () => <Gwangya />;
+
+export default GwangyaPage;

--- a/src/pageContainer/gwangya/index.tsx
+++ b/src/pageContainer/gwangya/index.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import * as S from './style';
+
+import { Header } from '@/components';
+
+const Gwangya = () => (
+  <>
+    <Header />
+    <S.Container>
+      <S.TitleBox>
+        <S.Title>광야</S.Title>
+        <S.Description>
+          익명으로 자유롭게 소통할 수 있는 광소마의 넓은 들판입니다.
+        </S.Description>
+      </S.TitleBox>
+    </S.Container>
+  </>
+);
+
+export default Gwangya;

--- a/src/pageContainer/gwangya/style.ts
+++ b/src/pageContainer/gwangya/style.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  padding-top: 4.375rem;
+  position: relative;
+
+  @media (max-width: 600px) {
+    padding: 7.5rem 1rem 0 1rem;
+  }
+`;
+
+export const TitleBox = styled.div`
+  display: flex;
+  align-items: end;
+  gap: 0.75rem;
+  margin-top: 2.5rem;
+`;
+
+export const Title = styled.h1`
+  ${({ theme }) => theme.typo.h4};
+  color: ${({ theme }) => theme.color.black};
+`;
+
+export const Description = styled.p`
+  ${({ theme }) => theme.typo.caption};
+  color: ${({ theme }) => theme.color.grey[500]};
+`;

--- a/src/pageContainer/index.ts
+++ b/src/pageContainer/index.ts
@@ -1,3 +1,4 @@
+export { default as Gwangya } from './gwangya';
 export { default as MentorRegister } from './register/mentor';
 export { default as MyInfoPage } from './mypage';
 export { default as SignIn } from './signin';


### PR DESCRIPTION
## 개요 💡

커뮤니티 - 광야의 페이지 틀을 제작했습니다.

## 작업내용 ⌨️

<img width="500" alt="스크린샷 2023-11-23 16 09 57" src="https://github.com/themoment-team/GSM-Networking-front/assets/80103328/c3cbcd4c-1147-48cd-a941-b19b3ba2a030">

- pageContainer/gwangya 추가
- app/community/gwangya/page.tsx 추가