### PR TITLE
Hotfix Register tenure Error

### DIFF
--- a/src/components/CareerRegistrationBox/index.tsx
+++ b/src/components/CareerRegistrationBox/index.tsx
@@ -18,6 +18,7 @@ import {
   defaultCareer,
 } from '@/constants';
 import type { CareerFormType, PositionType } from '@/types';
+import { deepCopy } from '@/utils';
 
 interface Props {
   career: CareerFormType;
@@ -108,7 +109,7 @@ const CareerRegistrationBox: React.FC<Props> = ({
     setCareerArray((prev) =>
       prev.map((career) => {
         if (career.id === id) {
-          const newCareer = { ...career };
+          const newCareer = deepCopy<CareerFormType>(career);
 
           const isChecked = e.target.checked;
 


### PR DESCRIPTION
## 개요 💡

- 재직 중 클릭 시, 모든 경력이 재직 상태로 변경되는 에러가 발생했습니다

## 작업내용 ⌨️

객체를 복사할 때, 얕은 복사가 되어 이런 에러가 발생하였고,
깊은 복사 방식으로 변경하여 해당 현상이 발생하지 않습니다