### PR TITLE
Add gwangya token logic

### DIFF
--- a/src/app/auth/refresh/gwangya/route.ts
+++ b/src/app/auth/refresh/gwangya/route.ts
@@ -1,0 +1,53 @@
+import { cookies } from 'next/headers';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { gwangyaUrl } from '@/libs';
+import type { GetGwangyaTokenType } from '@/types';
+
+const cookieDomain =
+  process.env.NODE_ENV === 'development' ? 'localhost' : '.gsm-networking.com';
+
+const setCookie = (name: string, value: string, expires: Date) => {
+  cookies().set(name, value, {
+    expires,
+    domain: cookieDomain,
+  });
+};
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+
+  const redirectPath = searchParams.get('redirect') || '/';
+
+  const cookieStore = cookies();
+
+  const accessToken = cookieStore.get('accessToken')?.value;
+
+  const res = await fetch(
+    new URL(`/api/v1${gwangyaUrl.getGwangyaToken()}`, process.env.BASE_URL),
+    {
+      method: 'GET',
+      headers: {
+        Cookie: `accessToken=${accessToken}`,
+      },
+    }
+  );
+
+  if (!res.ok) {
+    return NextResponse.redirect(
+      new URL(`/auth/refresh?redirect=/auth/refresh}`, request.url)
+    );
+  }
+
+  const body: GetGwangyaTokenType = await res.json();
+
+  const gwangyaToken = body.gwangyaToken;
+  const expires = body.expiredTime;
+
+  const expiresDate = new Date(`${expires}Z`);
+
+  setCookie('gwangyaToken', gwangyaToken, expiresDate);
+
+  return NextResponse.redirect(new URL(redirectPath, request.url));
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,8 +30,11 @@ export const metadata: Metadata = {
 
 const getMentorList = async (): Promise<WorkerType[]> => {
   const accessToken = cookies().get('accessToken')?.value;
+  const gwangyaToken = cookies().get('gwangyaToken')?.value;
 
   if (!accessToken) return redirect('/auth/refresh');
+
+  if (!gwangyaToken) return redirect('/auth/refresh/gwangya');
 
   const response = await fetch(
     new URL(`/api/v1${mentorUrl.getMentorList()}`, process.env.BASE_URL),

--- a/src/libs/api/axiosInstance.ts
+++ b/src/libs/api/axiosInstance.ts
@@ -8,6 +8,9 @@ export const axiosInstance = axios.create({
   withCredentials: true,
 });
 
+const cookieDomain =
+  process.env.NODE_ENV === 'development' ? 'localhost' : '.gsm-networking.com';
+
 let isRefreshing = false;
 
 /**
@@ -40,7 +43,7 @@ axiosInstance.interceptors.request.use(
 
       const cookieExpiredTime = new Date(expiredTime);
 
-      document.cookie = `gwangyaToken=${gwangyaToken}; expires=${cookieExpiredTime.toString()}`;
+      document.cookie = `gwangyaToken=${gwangyaToken}; Domain=${cookieDomain}; expires=${cookieExpiredTime.toString()}`;
     }
 
     return config;

--- a/src/libs/api/requestUrlController.ts
+++ b/src/libs/api/requestUrlController.ts
@@ -8,6 +8,10 @@ export const fileUrl = {
   postUploadFile: () => '/file',
 };
 
+export const gwangyaUrl = {
+  getGwangyaToken: () => `/gwangya/token`,
+};
+
 export const menteeUrl = {
   postMenteeRole: () => '/mentee',
 };

--- a/src/types/gwangya.ts
+++ b/src/types/gwangya.ts
@@ -1,0 +1,4 @@
+export interface GetGwangyaTokenType {
+  gwangyaToken: string;
+  expiredTime: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from './auth';
 export * from './career';
 export * from './generation';
+export * from './gwangya';
 export * from './mentor';
 export * from './mentorInfo';
 export * from './mentorInfoForm';


### PR DESCRIPTION
## 개요 💡

광야 서비스를 위한 gwangya token 로직을 추가했습니다.

## 작업내용 ⌨️

- client side fetching 
  - axios request interceptor에서 gwangya token 발급/갱신
- server side fetching
  - /auth/refresh/gwanya/route.ts에 gwangya token 발급/갱신
  - 현재는 Home말고는 마땅히 사용할 부분이 없어 Home 이외 다른 페이지에는 추가하지 않았습니다.
  - 추후에 gwangya page에도 추가하여 페이지 진입 전, gwangya token 발급/갱신 및 token 없는 회원 필터링 구현하겠습니다.
  
## 테스트 해주실 부분

1, /mypage 직접 접근 시(client side fetching), gwangyaToken 잘 발급되는지 확인
2. / 직접 접근 시(server side fetching), gwangyaToken 잘 발급되는지 확인