### PR TITLE
Migrate useGetGwangyaPostList useQuery => useInfiniteQuery

### DIFF
--- a/src/app/community/gwangya/page.tsx
+++ b/src/app/community/gwangya/page.tsx
@@ -1,4 +1,9 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import { gwangyaUrl } from '@/libs';
 import { Gwangya } from '@/pageContainer';
+import type { GwangyaPostType } from '@/types';
 
 import type { Metadata } from 'next';
 
@@ -7,6 +12,37 @@ export const metadata: Metadata = {
   description: '익명으로 자유롭게 소통할 수 있는 광소마의 넓은 들판입니다.',
 };
 
-const GwangyaPage = () => <Gwangya />;
+const GwangyaPage = async () => {
+  const postList = await getGwangyaPostList();
+
+  return <Gwangya initialData={postList} />;
+};
+
+const getGwangyaPostList = async (): Promise<GwangyaPostType[]> => {
+  const gwangyaToken = cookies().get('gwangyaToken')?.value;
+
+  if (!gwangyaToken)
+    return redirect('/auth/refresh/gwangya?redirect=/community/gwangya');
+
+  const response = await fetch(
+    new URL(
+      `/api/v1${gwangyaUrl.getGwangyaPostList(0)}`,
+      process.env.NEXT_PUBLIC_API_BASE_URL
+    ),
+    { headers: { GwangyaToken: gwangyaToken } }
+  );
+
+  if (response.status === 401) {
+    return redirect('/auth/refresh/gwangya?redirect=/community/gwangya');
+  }
+
+  if (!response.ok) {
+    return redirect('/auth/signin');
+  }
+
+  const postList: GwangyaPostType[] = await response.json();
+
+  return postList;
+};
 
 export default GwangyaPage;

--- a/src/components/TextArea/style.ts
+++ b/src/components/TextArea/style.ts
@@ -5,7 +5,7 @@ export const TextAreaContainer = styled.div<{ isFocused: boolean }>`
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem 1.25rem 0.75rem 1.25rem;
-  width: 37.5rem;
+  max-width: 37.5rem;
   height: auto;
   border: 0.0625rem solid
     ${({ theme, isFocused }) =>

--- a/src/hooks/api/gwangya/useGetGwangyaPostList.ts
+++ b/src/hooks/api/gwangya/useGetGwangyaPostList.ts
@@ -22,7 +22,7 @@ export const useGetGwangyaPostList = (initialData?: GwangyaPostType[]) =>
         }
       ),
     initialPageParam: 0,
-    getPreviousPageParam: (firstPage) => firstPage[0]?.id ?? undefined,
+    getPreviousPageParam: (firstPage) => firstPage[0]?.id,
     getNextPageParam: (lastPage) => lastPage[lastPage.length - 1].id,
     initialData: initialData && { pages: [initialData], pageParams: [0] },
   });

--- a/src/hooks/api/gwangya/useGetGwangyaPostList.ts
+++ b/src/hooks/api/gwangya/useGetGwangyaPostList.ts
@@ -1,24 +1,18 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { get, gwangyaQueryKeys, gwangyaUrl } from '@/libs';
 import type { GwangyaPostType } from '@/types';
 import { getGwangyaTokenCookie } from '@/utils';
 
-import type { UseQueryOptions } from '@tanstack/react-query';
-import type { AxiosError } from 'axios';
-
 const gwangyaToken = getGwangyaTokenCookie();
 
 // TODO: useInfiniteQuery로 전환
-export const useGetGwangyaPostList = (
-  gwangyaId: number,
-  options?: UseQueryOptions<GwangyaPostType[], AxiosError>
-) =>
-  useQuery({
+export const useGetGwangyaPostList = (initialData?: GwangyaPostType[]) =>
+  useInfiniteQuery({
     queryKey: gwangyaQueryKeys.getGwangyaPostList(),
-    queryFn: () =>
+    queryFn: ({ pageParam }) =>
       get<GwangyaPostType[]>(
-        `/api/v1${gwangyaUrl.getGwangyaPostList(gwangyaId)}`,
+        `/api/v1${gwangyaUrl.getGwangyaPostList(pageParam)}`,
         {
           baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
           headers: {
@@ -27,5 +21,8 @@ export const useGetGwangyaPostList = (
           withCredentials: false,
         }
       ),
-    ...options,
+    initialPageParam: 0,
+    getPreviousPageParam: (firstPage) => firstPage[0]?.id ?? undefined,
+    getNextPageParam: (lastPage) => lastPage[lastPage.length - 1].id,
+    initialData: initialData && { pages: [initialData], pageParams: [0] },
   });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './api';
 export * from './useAutoSizeTextArea';
 export * from './useForwardRef';
+export * from './useGetRem';

--- a/src/hooks/useGetRem.ts
+++ b/src/hooks/useGetRem.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+
+export const useGetRem = () => {
+  const [rem, setRem] = useState(16);
+
+  const updateRem = (width: number) => {
+    setRem(() => {
+      if (width > 600) {
+        return 16;
+      } else if (width > 530) {
+        return 15;
+      } else if (width > 490) {
+        return 14;
+      } else if (width > 460) {
+        return 13;
+      } else if (width > 420) {
+        return 12;
+      } else if (width > 390) {
+        return 11;
+      } else if (width > 350) {
+        return 10;
+      } else if (width > 320) {
+        return 9;
+      } else {
+        return 8;
+      }
+    });
+  };
+
+  useEffect(() => {
+    let resizeTimer: NodeJS.Timeout;
+
+    const handleResize = () => {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => updateRem(window.innerWidth), 100);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    handleResize();
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return rem;
+};

--- a/src/pageContainer/gwangya/index.tsx
+++ b/src/pageContainer/gwangya/index.tsx
@@ -5,18 +5,62 @@ import { useEffect, useRef } from 'react';
 import * as S from './style';
 
 import { Header, CommunityCard, TextArea } from '@/components';
-import { useGetGwangyaPostList } from '@/hooks';
+import { useGetGwangyaPostList, useGetRem } from '@/hooks';
+import type { GwangyaPostType } from '@/types';
 
-const Gwangya = () => {
+interface Props {
+  initialData: GwangyaPostType[];
+}
+
+const Gwangya: React.FC<Props> = ({ initialData }) => {
+  const rem = useGetRem();
+
   const postListRef = useRef<HTMLDivElement>(null);
+  const loadMoreTriggerRef = useRef<HTMLDivElement>(null);
 
-  const { data } = useGetGwangyaPostList(0);
+  const { data, fetchPreviousPage, isFetchingPreviousPage, hasPreviousPage } =
+    useGetGwangyaPostList(initialData);
+
+  // 이전 데이터를 가져올 시, 스크롤이 최상단에 멈무는 현상 해결
+  useEffect(() => {
+    const cardHeight = 4.6819 * rem;
+    const gap = 2.25 * rem;
+
+    // gap은 카드 개수 - 1 만큼 존재하여 마지막에는 빼줘야함
+    const scrollHeight =
+      (data && data?.pages[0].length * (cardHeight + gap) - gap) || 0;
+    postListRef.current?.scrollTo(0, scrollHeight);
+  }, [data, rem]);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleObserver = (
+    [entry]: IntersectionObserverEntry[],
+    observer: IntersectionObserver
+  ) => {
+    if (entry.isIntersecting) {
+      observer.unobserve(entry.target);
+
+      fetchPreviousPage();
+
+      observer.observe(entry.target);
+    }
+  };
 
   useEffect(() => {
-    if ((data?.length ?? 0) <= 20) {
-      postListRef.current?.scrollTo(0, 99999);
-    }
-  }, [data]);
+    if (!loadMoreTriggerRef.current) return;
+
+    const option = {
+      root: null,
+      rootMargin: '0px',
+      threshold: 0,
+    };
+
+    const observer = new IntersectionObserver(handleObserver, option);
+
+    observer.observe(loadMoreTriggerRef.current);
+
+    return () => observer.disconnect();
+  }, [handleObserver]);
 
   return (
     <>
@@ -30,7 +74,12 @@ const Gwangya = () => {
         </S.TitleBox>
         <S.PostWrapper>
           <S.PostList ref={postListRef}>
-            {data?.map((post) => <CommunityCard key={post.id} {...post} />)}
+            {!isFetchingPreviousPage && hasPreviousPage && (
+              <S.LoadMoreTrigger ref={loadMoreTriggerRef} />
+            )}
+            {data?.pages.map((page) =>
+              page.map((post) => <CommunityCard key={post.id} {...post} />)
+            )}
           </S.PostList>
           <TextArea />
         </S.PostWrapper>

--- a/src/pageContainer/gwangya/style.ts
+++ b/src/pageContainer/gwangya/style.ts
@@ -5,7 +5,7 @@ export const Container = styled.div`
   position: relative;
 
   @media (max-width: 600px) {
-    padding: 7.5rem 1rem 0 1rem;
+    padding: 4.375rem 1rem 0 1rem;
   }
 `;
 
@@ -35,9 +35,15 @@ export const PostWrapper = styled.div`
   gap: 1.25rem;
 `;
 
+export const LoadMoreTrigger = styled.div`
+  position: absolute;
+  top: 0px;
+`;
+
 export const PostList = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2.25rem;
   overflow-y: scroll;
+  position: relative;
 `;


### PR DESCRIPTION
## 개요 💡

useGetGwangyaPostList의 단순 연동 상태에서 무한 스크롤을 적용하기 위해 useQuery => useInfiniteQuery 마이그레이션을 했습니다.

## 작업내용 ⌨️

- `/community/gwangya` server side fetching 추가
  - token 검증 및 token 유무에 따른 리다이렉트 
  - useGetGwangyaPostList의 initial data로 해당 응답을 할당함
- useQuery => useInfiniteQuery 마이그레이션
  - https://tanstack.com/query/latest/docs/react/reference/useInfiniteQuery
  - 서비스 특성 상 getNextPageParam이 아닌, getPreviousPageParam 및 fetchPreviousPage을 사용합니다.
- 1rem 값을 가져오는 useGetRem hook 추가

### 무한 스크롤 동작 방식

1. IntersectionObserver로 LoadMoreTrigger를 관찰합니다.
2. 뷰포트에 LoadMoreTrigger가 노출되면 관찰을 멈춥니다. 
3. fetchPreviousPage를 호출합니다.
4. 다시 관찰을 시작합니다.

### 개발 중 이슈

상단으로 스크롤하여 이전 게시글들을 가져온 이후, 
스크롤이 상단에 고정된 상태가 유지되어,
LoadMoreTrigger가 노출된 상태가 유지되어 1, 2, 3 .. page들을 중단없이 가져와버리는 현상이 발생했습니다.

따라서 아래 코드를 통해

<img width="500" alt="스크린샷 2023-11-29 23 24 55" src="https://github.com/themoment-team/GSM-Networking-front/assets/80103328/1bda70b4-b386-4e4c-b1f4-18e5ba235284">

fetching 이후 수동으로 새로 받아온 리스트의 첫 게시글(이전 페이지의 마지막 게시글) 부근으로 스크롤 되도록 코드로 작성했습니다.
