### PR TITLE
Update Gwangya overall fix

### DIFF
--- a/src/app/auth/refresh/gwangya/route.ts
+++ b/src/app/auth/refresh/gwangya/route.ts
@@ -36,7 +36,7 @@ export async function GET(request: NextRequest) {
 
   if (!res.ok) {
     return NextResponse.redirect(
-      new URL(`/auth/refresh?redirect=/auth/refresh}`, request.url)
+      new URL(`/auth/refresh?redirect=/auth/refresh/gwangya`, request.url)
     );
   }
 

--- a/src/app/auth/refresh/gwangya/route.ts
+++ b/src/app/auth/refresh/gwangya/route.ts
@@ -18,7 +18,7 @@ const setCookie = (name: string, value: string, expires: Date) => {
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
 
-  const redirectPath = searchParams.get('redirect') || '/';
+  const redirectPath = searchParams.get('redirect') || '/community/gwangya';
 
   const cookieStore = cookies();
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,7 +34,7 @@ const getMentorList = async (): Promise<WorkerType[]> => {
 
   if (!accessToken) return redirect('/auth/refresh');
 
-  if (!gwangyaToken) return redirect('/auth/refresh/gwangya');
+  if (!gwangyaToken) return redirect('/auth/refresh/gwangya?redirect=/');
 
   const response = await fetch(
     new URL(`/api/v1${mentorUrl.getMentorList()}`, process.env.BASE_URL),

--- a/src/components/CommunityCard/index.tsx
+++ b/src/components/CommunityCard/index.tsx
@@ -10,7 +10,7 @@ const addZero = (num: number): string => (num < 10 ? `0${num}` : `${num}`);
 
 const CommunityCard = forwardRef<HTMLDivElement, GwangyaPostType>(
   ({ id, content, createdAt }, ref) => {
-    const createdDate = new Date(createdAt);
+    const createdDate = new Date(createdAt + 'Z');
 
     const createdMonth = createdDate.getMonth() + 1;
     const createdDay = createdDate.getDate();

--- a/src/components/CommunityCard/index.tsx
+++ b/src/components/CommunityCard/index.tsx
@@ -8,6 +8,8 @@ import type { GwangyaPostType } from '@/types';
 
 const addZero = (num: number): string => (num < 10 ? `0${num}` : `${num}`);
 
+const removeDuplicateEnter = (str: string) => str.replaceAll(/\n+/g, '\n');
+
 const CommunityCard = forwardRef<HTMLDivElement, GwangyaPostType>(
   ({ id, content, createdAt }, ref) => {
     const createdDate = new Date(createdAt + 'Z');
@@ -34,7 +36,7 @@ const CommunityCard = forwardRef<HTMLDivElement, GwangyaPostType>(
             </S.Time>
           </S.DateBox>
         </S.Header>
-        <S.Content>{content}</S.Content>
+        <S.Content>{removeDuplicateEnter(content)}</S.Content>
       </S.CardWrapper>
     );
   }

--- a/src/components/CommunityCard/style.ts
+++ b/src/components/CommunityCard/style.ts
@@ -31,6 +31,8 @@ export const Date = styled.p``;
 export const Time = styled.time``;
 
 export const Content = styled.pre`
+  width: 100%;
+  white-space: break-spaces;
   ${({ theme }) => theme.typo.body1}
   color: #000000;
 `;

--- a/src/components/CommunityCard/style.ts
+++ b/src/components/CommunityCard/style.ts
@@ -30,7 +30,7 @@ export const Date = styled.p``;
 
 export const Time = styled.time``;
 
-export const Content = styled.p`
+export const Content = styled.pre`
   ${({ theme }) => theme.typo.body1}
   color: #000000;
 `;

--- a/src/hooks/api/gwangya/useGetGwangyaPostList.ts
+++ b/src/hooks/api/gwangya/useGetGwangyaPostList.ts
@@ -23,6 +23,6 @@ export const useGetGwangyaPostList = (initialData?: GwangyaPostType[]) =>
       ),
     initialPageParam: 0,
     getPreviousPageParam: (firstPage) => firstPage[0]?.id,
-    getNextPageParam: (lastPage) => lastPage[lastPage.length - 1].id,
+    getNextPageParam: (lastPage) => lastPage[lastPage.length - 1]?.id,
     initialData: initialData && { pages: [initialData], pageParams: [0] },
   });

--- a/src/libs/api/axiosInstance.ts
+++ b/src/libs/api/axiosInstance.ts
@@ -45,7 +45,7 @@ axiosInstance.interceptors.request.use(
 
       document.cookie = `gwangyaToken=${gwangyaToken}; Domain=${cookieDomain}; expires=${cookieExpiredTime.toString()}`;
 
-      if (config.url?.includes('/api/v1/gwangya')) {
+      if (config.url?.includes('api/v1/gwangya')) {
         config.headers.gwangyatoken = gwangyaToken;
       }
     }


### PR DESCRIPTION
## 개요 💡

CommunityCard Date 객체 생성 방식을 변경하였습니다.

## 작업내용 ⌨️

- api에서 반환되는 createdAt이 UTC 형식으로 반환되어 Date 객체 생성 시, UTC 시간대 임을 표기해줍니다

### before

<img width="600" alt="스크린샷 2023-12-04 16 55 31" src="https://github.com/themoment-team/GSM-Networking-front/assets/80103328/fbca9267-8a51-46f6-8019-6738c10f5fa3">

### after 

<img width="600" alt="스크린샷 2023-12-04 16 55 26" src="https://github.com/themoment-team/GSM-Networking-front/assets/80103328/af0ec986-04c0-4a10-9658-070e72d26ede">

### 추가 작업 내용

- 잘못된 refresh logic 들의 refresh path 수정
- CommunityCard의 content tag를 p => pre 로 변경
- gwangya api 요청 여부 검증 path 변경
  - `/api/v1/gwangya` => `api/v1/gwangya`
