### PR TITLE
[hotfix] Prevent duplicated cookie

### DIFF
--- a/src/app/community/gwangya/page.tsx
+++ b/src/app/community/gwangya/page.tsx
@@ -36,6 +36,8 @@ const getGwangyaPostList = async (): Promise<GwangyaPostType[]> => {
   );
 
   if (response.status === 401) {
+    // eslint-disable-next-line no-console
+    console.log(response.body);
     return redirect('/auth/refresh/gwangya?redirect=/community/gwangya');
   }
 

--- a/src/app/community/gwangya/page.tsx
+++ b/src/app/community/gwangya/page.tsx
@@ -21,9 +21,6 @@ const GwangyaPage = async () => {
 const getGwangyaPostList = async (): Promise<GwangyaPostType[]> => {
   const gwangyaToken = cookies().get('gwangyaToken')?.value;
 
-  // eslint-disable-next-line no-console
-  console.log(gwangyaToken);
-
   if (!gwangyaToken)
     return redirect('/auth/refresh/gwangya?redirect=/community/gwangya');
 
@@ -36,8 +33,6 @@ const getGwangyaPostList = async (): Promise<GwangyaPostType[]> => {
   );
 
   if (response.status === 401) {
-    // eslint-disable-next-line no-console
-    console.log(response.body);
     return redirect('/auth/refresh/gwangya?redirect=/community/gwangya');
   }
 

--- a/src/app/community/gwangya/page.tsx
+++ b/src/app/community/gwangya/page.tsx
@@ -21,6 +21,9 @@ const GwangyaPage = async () => {
 const getGwangyaPostList = async (): Promise<GwangyaPostType[]> => {
   const gwangyaToken = cookies().get('gwangyaToken')?.value;
 
+  // eslint-disable-next-line no-console
+  console.log(gwangyaToken);
+
   if (!gwangyaToken)
     return redirect('/auth/refresh/gwangya?redirect=/community/gwangya');
 

--- a/src/libs/api/axiosInstance.ts
+++ b/src/libs/api/axiosInstance.ts
@@ -43,7 +43,7 @@ axiosInstance.interceptors.request.use(
 
       const cookieExpiredTime = new Date(expiredTime);
 
-      document.cookie = `gwangyaToken=${gwangyaToken}; Domain=${cookieDomain}; expires=${cookieExpiredTime.toString()}`;
+      document.cookie = `gwangyaToken=${gwangyaToken}; Domain=${cookieDomain}; expires=${cookieExpiredTime.toString()}; path=/;`;
 
       if (config.url?.includes('api/v1/gwangya')) {
         config.headers.gwangyatoken = gwangyaToken;


### PR DESCRIPTION
## 개요 💡

같은 키의 쿠키가 생성되는 현상을 막았습니다.

## 작업내용 ⌨️

- axios interceptor에서 gwangyaToken 재발급 시의 쿠키 중복 생성 문제 해결
  - 서비스 내에서 하나의 cookie로 gwangyaToken을 관리하기 위해, path에 root를 주었습니다