### PR TITLE
Mentor register form refectoring

### DIFF
--- a/src/components/CareerRegistrationBox/index.tsx
+++ b/src/components/CareerRegistrationBox/index.tsx
@@ -116,8 +116,6 @@ const CareerRegistrationBox: React.FC<Props> = ({
           newCareer.isWorking.value = isChecked;
 
           if (isChecked) {
-            if (endYearRef.current) endYearRef.current.value = '';
-            if (endMonthRef.current) endMonthRef.current.value = '';
             newCareer.endYear.value = '년';
             newCareer.endYear.errorMessage = null;
             newCareer.endMonth.value = '월';
@@ -163,11 +161,12 @@ const CareerRegistrationBox: React.FC<Props> = ({
           errorMessage={companyUrl.errorMessage}
         />
         <SelectFormItem
+          value={position.value}
           required
           selectTitle='포지션(직책, 직무)'
           options={[...POSITION_ARRAY]}
-          errorMessage={position.errorMessage}
           defaultValue='포지션 선택'
+          errorMessage={position.errorMessage}
           onChange={handlePositionChange}
         />
         <S.EmploymentDurationBox>
@@ -183,31 +182,35 @@ const CareerRegistrationBox: React.FC<Props> = ({
           >
             <S.PeriodSelectWrapper>
               <Select
-                defaultValue={startYear.value}
+                value={startYear.value}
                 options={[...YEAR_ARRAY]}
+                defaultValue='년'
                 onChange={(e) => handlePeriodChange(e, 'startYear')}
                 errorMessage={startYear.errorMessage}
               />
               <Select
-                defaultValue={startMonth.value}
+                value={startMonth.value}
                 options={[...MONTH_ARRAY]}
+                defaultValue='월'
                 onChange={(e) => handlePeriodChange(e, 'startMonth')}
                 errorMessage={startMonth.errorMessage}
               />
               <S.Tilde>~</S.Tilde>
               <Select
                 ref={endYearRef}
-                defaultValue={endYear.value}
+                value={endYear.value}
                 options={[...YEAR_ARRAY]}
                 disabled={isWorking.value}
+                defaultValue='년'
                 onChange={(e) => handlePeriodChange(e, 'endYear')}
                 errorMessage={endYear.errorMessage}
               />
               <Select
                 ref={endMonthRef}
-                defaultValue={endMonth.value}
+                value={endMonth.value}
                 options={[...MONTH_ARRAY]}
                 disabled={isWorking.value}
+                defaultValue='월'
                 onChange={(e) => handlePeriodChange(e, 'endMonth')}
                 errorMessage={endMonth.errorMessage}
               />
@@ -217,6 +220,7 @@ const CareerRegistrationBox: React.FC<Props> = ({
             type='checkbox'
             id={`checkbox-${id}`}
             onChange={handleTenureCheck}
+            checked={isWorking.value}
           />
           <S.TenureCheckLabel htmlFor={`checkbox-${id}`}>
             <S.CheckBox isChecked={isWorking.value}>

--- a/src/components/FormItem/Select/index.tsx
+++ b/src/components/FormItem/Select/index.tsx
@@ -3,7 +3,6 @@
 import { forwardRef } from 'react';
 
 import { FormItemWrapper, Select } from '@/components';
-import { useForwardRef } from '@/hooks';
 
 interface Props extends React.SelectHTMLAttributes<HTMLSelectElement> {
   selectTitle: string;
@@ -14,24 +13,20 @@ interface Props extends React.SelectHTMLAttributes<HTMLSelectElement> {
 }
 
 const SelectFormItem = forwardRef<HTMLSelectElement, Props>(
-  ({ selectTitle, errorMessage, options, required, ...attributes }, ref) => {
-    const selectRef = useForwardRef<HTMLSelectElement>(ref);
-
-    return (
-      <FormItemWrapper
-        title={selectTitle}
+  ({ selectTitle, errorMessage, options, required, ...attributes }, ref) => (
+    <FormItemWrapper
+      title={selectTitle}
+      errorMessage={errorMessage}
+      required={required}
+    >
+      <Select
+        options={[...options]}
         errorMessage={errorMessage}
-        required={required}
-      >
-        <Select
-          options={[...options]}
-          errorMessage={errorMessage}
-          ref={selectRef}
-          {...attributes}
-        />
-      </FormItemWrapper>
-    );
-  }
+        ref={ref}
+        {...attributes}
+      />
+    </FormItemWrapper>
+  )
 );
 
 SelectFormItem.displayName = 'Input';

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,11 +1,8 @@
 'use client';
 
-import type { ChangeEvent } from 'react';
-import { forwardRef, useState } from 'react';
+import { forwardRef } from 'react';
 
 import * as S from './style';
-
-import { useForwardRef } from '@/hooks';
 
 interface Props extends React.InputHTMLAttributes<HTMLSelectElement> {
   errorMessage?: string | null;
@@ -18,35 +15,24 @@ interface Props extends React.InputHTMLAttributes<HTMLSelectElement> {
  * @param options - options 배열
  */
 const Select = forwardRef<HTMLSelectElement, Props>(
-  ({ errorMessage, options, defaultValue, onChange, ...attributes }, ref) => {
-    const [isDefault, setIsDefault] = useState<boolean>(true);
-    const selectRef = useForwardRef<HTMLSelectElement>(ref);
-
-    const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
-      setIsDefault(e.target.value === defaultValue);
-      onChange && onChange(e);
-    };
-
-    return (
-      <S.CustomSelect
-        isError={!!errorMessage}
-        ref={selectRef}
-        isDefault={isDefault}
-        defaultValue={defaultValue}
-        onChange={handleChange}
-        {...attributes}
-      >
-        <option disabled hidden value={defaultValue}>
-          {defaultValue}
+  ({ errorMessage, options, defaultValue, value, ...attributes }, ref) => (
+    <S.CustomSelect
+      isError={!!errorMessage}
+      ref={ref}
+      isDefault={value === defaultValue}
+      value={value}
+      {...attributes}
+    >
+      <option disabled hidden value={defaultValue}>
+        {defaultValue}
+      </option>
+      {options.map((option) => (
+        <option key={option} value={option}>
+          {option}
         </option>
-        {options.map((option) => (
-          <option key={option} value={option}>
-            {option}
-          </option>
-        ))}
-      </S.CustomSelect>
-    );
-  }
+      ))}
+    </S.CustomSelect>
+  )
 );
 
 Select.displayName = 'Select';

--- a/src/components/Select/style.ts
+++ b/src/components/Select/style.ts
@@ -19,11 +19,8 @@ export const CustomSelect = styled.select<{
 
   :disabled {
     background-color: ${({ theme }) => theme.color.grey[50]};
+    color: ${({ theme }) => theme.color.grey[200]};
     cursor: default;
-  }
-
-  ::placeholder {
-    color: ${({ theme }) => theme.color.grey[400]};
   }
 
   :focus {

--- a/src/pageContainer/register/mentor/index.tsx
+++ b/src/pageContainer/register/mentor/index.tsx
@@ -76,13 +76,14 @@ const MentorRegister: React.FC<Props> = ({ tempMentorId, mentorInfo }) => {
     handleSubmit,
     formState: { errors },
     setValue,
+    watch,
   } = useForm<MentorInfoFormType>({
     resolver: zodResolver(mentorInfoFormSchema),
     defaultValues: {
       name: mentorInfo?.name ?? '',
       phoneNumber: '',
       email: mentorInfo?.email ?? '',
-      generation: mentorInfo?.generation.toString() ?? undefined,
+      generation: mentorInfo?.generation.toString() ?? '기수를 선택해주세요.',
       snsUrl: mentorInfo?.SNS ?? '',
     },
   });
@@ -220,6 +221,7 @@ const MentorRegister: React.FC<Props> = ({ tempMentorId, mentorInfo }) => {
               {...register('generation')}
               selectTitle='기수'
               options={[...GENERATION_ARRAY]}
+              value={watch('generation')}
               defaultValue='기수를 선택해주세요.'
               errorMessage={errors.generation?.message}
               required={true}

--- a/src/pageContainer/register/mentor/index.tsx
+++ b/src/pageContainer/register/mentor/index.tsx
@@ -121,7 +121,7 @@ const MentorRegister: React.FC<Props> = ({ tempMentorId, mentorInfo }) => {
       setValue('name', myInfoData.name);
       setValue('phoneNumber', myInfoData.phoneNumber);
       setValue('email', myInfoData.email);
-      setValue('snsUrl', myInfoData.SNS);
+      setValue('snsUrl', myInfoData.SNS ?? '');
       setValue('generation', myInfoData.generation.toString());
 
       setIsUpdate(true);

--- a/src/pageContainer/register/mentor/index.tsx
+++ b/src/pageContainer/register/mentor/index.tsx
@@ -25,12 +25,12 @@ import {
   usePostMentorRegister,
 } from '@/hooks';
 import { mentorInfoFormSchema } from '@/schemas';
-import type { RequestCareerType } from '@/types';
 import type {
   CareerFormType,
   MentorInfoFormType,
   MentorType,
   TempMentorType,
+  RequestCareerType,
 } from '@/types';
 import {
   careerValidation,
@@ -52,7 +52,7 @@ const MentorRegister: React.FC<Props> = ({ tempMentorId, mentorInfo }) => {
 
   const { push } = useRouter();
 
-  const { data, isError } = useGetMyInfo();
+  const { data: myInfoData, isError } = useGetMyInfo();
 
   const { mutate: mutateDeleteTempMentor } = useDeleteTempMentor({
     onSettled: () => push('/'),
@@ -88,9 +88,9 @@ const MentorRegister: React.FC<Props> = ({ tempMentorId, mentorInfo }) => {
   });
 
   useEffect(() => {
-    if (!data || isError) setIsUpdate(false);
+    if (!myInfoData || isError) setIsUpdate(false);
     else {
-      const career = data.career;
+      const career = myInfoData.career;
       const newCareerList: CareerFormType[] = career.map((career) => {
         const startDate = new Date(career.startDate);
         const endDate = career.endDate ? new Date(career.endDate) : null;
@@ -118,15 +118,15 @@ const MentorRegister: React.FC<Props> = ({ tempMentorId, mentorInfo }) => {
 
       setCareerArray(newCareerList);
 
-      setValue('name', data.name);
-      setValue('phoneNumber', data.phoneNumber);
-      setValue('email', data.email);
-      setValue('snsUrl', data.SNS);
-      setValue('generation', data.generation.toString());
+      setValue('name', myInfoData.name);
+      setValue('phoneNumber', myInfoData.phoneNumber);
+      setValue('email', myInfoData.email);
+      setValue('snsUrl', myInfoData.SNS);
+      setValue('generation', myInfoData.generation.toString());
 
       setIsUpdate(true);
     }
-  }, [data, isError, setValue]);
+  }, [myInfoData, isError, setValue]);
 
   const onSubmit: SubmitHandler<MentorInfoFormType> = (data) => {
     const validatedArray = careerValidation(careerArray, setCareerArray);


### PR DESCRIPTION
## 개요 💡

멘토 등록 폼 리펙토링을 진행했습니다.

## 작업내용 ⌨️

- useGetMyInfo에서 반환되는 data => myInfoData 명칭 변경
- 폼 내에 Select 를 사용하는 모든 컴포넌트를 [Controlled](https://react.dev/reference/react-dom/components/select#props) 방식으로 작동하도록 했습니다
  - 컴포넌트에 value를 넘기고 onChange, state로 값을 관리합니다.
  - 아래와 제어 컴포넌트에서는 `defaultValue`를 설정할 수 없기에 `defaultValue`가 오직 `option`의 요소로 동작되어 `value`에 `defaultValue`가 할당되어도 정상적으로 선택된 상태가 유지되도록 하였습니다.
    <img width="500" alt="스크린샷 2023-12-27 20 34 51" src="https://github.com/themoment-team/GSM-Networking-front/assets/80103328/71baacfe-601c-4383-bd60-606f4626d782">
- Select의 default 상태의 스타일을 수정했습니다.
- forwardRef가 감싸진 컴포넌트들 내부에서 ref를 사용하지 않고 바로 element에 ref를 할당하는 컴포넌트들의 useForwardRef를 제거했습니다.
