### PR TITLE
Add textArea in boardPage

### DIFF
--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -11,7 +11,7 @@ import { useAutoResizeTextArea } from '@/hooks';
 const MAX_LENGTH = 200;
 
 interface Props {
-  textAreaType: 'gwangya' | 'chatting';
+  textAreaType: 'gwangya' | 'chatting' | 'comment';
   onClick: (content: string) => void;
   disabled: boolean;
 }
@@ -26,6 +26,10 @@ const TextArea: React.FC<Props> = ({ textAreaType, onClick, disabled }) => {
     chatting: {
       placeholder: '메시지 보내기',
       icon: <SendIcon />,
+    },
+    comment: {
+      placeholder: '댓글은 최대 100자 까지 쓸 수 있습니다.',
+      icon: <UploadIcon />,
     },
   } as const;
 

--- a/src/pageContainer/community/board/detail/index.tsx
+++ b/src/pageContainer/community/board/detail/index.tsx
@@ -9,6 +9,7 @@ import {
   CommentCard,
   MiniProfile,
   ChattingButton,
+  TextArea,
 } from '@/components';
 import type { PostType, CommentType } from '@/types';
 
@@ -79,28 +80,39 @@ const Mock: PostType = {
   },
 };
 
-const PostDetail: React.FC<Props> = () => (
-  <S.Container>
-    <Header />
-    <S.PostContainer>
-      <SubFunctionHeader prevPath={PREV_PATH} title='글' />
-      <S.WriterProfileWrapper>
-        <MiniProfile profile={Mock.user} />
-        <ChattingButton onClick={() => {}} />
-      </S.WriterProfileWrapper>
-      <PostContent
-        title={Mock.title}
-        description={Mock.description}
-        category={Mock.category}
-      />
-      <S.Line />
-      <S.CommentContainer>
-        {Mock.comments.map((comment) => (
-          <CommentCard key={comment.id} comment={comment} />
-        ))}
-      </S.CommentContainer>
-    </S.PostContainer>
-  </S.Container>
-);
+const PostDetail: React.FC<Props> = () => {
+  const uploadComment = () => {};
+
+  return (
+    <S.Container>
+      <Header />
+      <S.PostContainer>
+        <SubFunctionHeader prevPath={PREV_PATH} title='글' />
+        <S.WriterProfileWrapper>
+          <MiniProfile profile={Mock.user} />
+          <ChattingButton onClick={() => {}} />
+        </S.WriterProfileWrapper>
+        <PostContent
+          title={Mock.title}
+          description={Mock.description}
+          category={Mock.category}
+        />
+        <S.Line />
+        <S.CommentContainer>
+          {Mock.comments.map((comment) => (
+            <CommentCard key={comment.id} comment={comment} />
+          ))}
+        </S.CommentContainer>
+      </S.PostContainer>
+      <S.TextAreaWrapper>
+        <TextArea
+          disabled={false}
+          onClick={uploadComment}
+          textAreaType='comment'
+        />
+      </S.TextAreaWrapper>
+    </S.Container>
+  );
+};
 
 export default PostDetail;

--- a/src/pageContainer/community/board/detail/style.ts
+++ b/src/pageContainer/community/board/detail/style.ts
@@ -36,4 +36,5 @@ export const TextAreaWrapper = styled.div`
   position: fixed;
   bottom: 2.5rem;
   width: 100%;
+  box-shadow: 0px -0.625rem 1rem 0px rgba(255, 255, 255, 0.8);
 `;

--- a/src/pageContainer/community/board/detail/style.ts
+++ b/src/pageContainer/community/board/detail/style.ts
@@ -6,7 +6,7 @@ const FlexBox = styled.div`
 `;
 
 export const Container = styled.div`
-  padding: 4.375rem 0;
+  padding: 4.375rem 0 6.75rem;
 `;
 
 export const PostContainer = styled(FlexBox)`

--- a/src/pageContainer/community/board/detail/style.ts
+++ b/src/pageContainer/community/board/detail/style.ts
@@ -31,3 +31,9 @@ export const Line = styled.div`
 export const CommentContainer = styled(FlexBox)`
   gap: 2.5rem;
 `;
+
+export const TextAreaWrapper = styled.div`
+  position: fixed;
+  bottom: 2.5rem;
+  width: 100%;
+`;


### PR DESCRIPTION
## 개요 💡

> TextArea 컴포넌트를 게시판 페이지에 추가했습니다.

## 작업내용 ⌨️
- TextArea컴포넌트를 comment 타입까지 확장시켰습니다.

<img width="450" alt="image" src="https://github.com/themoment-team/GSM-Networking-front/assets/106712562/81ca916f-fd07-4673-a35e-379b797df192">
