### PR TITLE
Publishing `community write page`

### DIFF
--- a/src/app/community/write/page.tsx
+++ b/src/app/community/write/page.tsx
@@ -1,0 +1,5 @@
+import { CommunityWrite } from '@/pageContainer';
+
+const CommunityWritePage = () => <CommunityWrite />;
+
+export default CommunityWritePage;

--- a/src/components/FormItem/Select/index.tsx
+++ b/src/components/FormItem/Select/index.tsx
@@ -12,6 +12,15 @@ interface Props extends React.SelectHTMLAttributes<HTMLSelectElement> {
   required?: boolean;
 }
 
+/**
+ * Select Form Item
+ *
+ * defaultValue 사용법
+ * 1. options 배열에 defaultValue를 포함하지 않고 넘긴다.
+ * 2. value에 useForm.watch('fieldName')을 넘긴다.
+ *
+ * 참고 -  넘겨진 defaultValue는 기본적으로 사용자가 선택할 수 없도록 구현되었다.
+ */
 const SelectFormItem = forwardRef<HTMLSelectElement, Props>(
   ({ selectTitle, errorMessage, options, required, ...attributes }, ref) => (
     <FormItemWrapper

--- a/src/pageContainer/community/write/index.tsx
+++ b/src/pageContainer/community/write/index.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import * as S from './style';
+
+import {
+  FormItemWrapper,
+  Header,
+  InputFormItem,
+  SelectFormItem,
+  SubFunctionHeader,
+} from '@/components';
+
+const CommunityWrite = () => (
+  <>
+    <Header />
+    <S.Container>
+      <SubFunctionHeader prevPath='/community' title='글 작성' />
+      <S.Form>
+        <S.FormFieldsWrapper>
+          <SelectFormItem
+            // value={watch('category')}
+            value={'글 카테고리'}
+            options={['전공', '스포츠']}
+            selectTitle='카테고리'
+            defaultValue={'글 카테고리'}
+          />
+          <InputFormItem inputTitle='제목' placeholder='50자 이내' />
+          <FormItemWrapper title='내용'>
+            <S.Textarea placeholder='1000자 이내' isError={false} />
+          </FormItemWrapper>
+        </S.FormFieldsWrapper>
+        <S.NextButton type='submit'>다음</S.NextButton>
+      </S.Form>
+    </S.Container>
+  </>
+);
+
+export default CommunityWrite;

--- a/src/pageContainer/community/write/style.ts
+++ b/src/pageContainer/community/write/style.ts
@@ -1,0 +1,59 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  padding: 4.375rem 0 2.5rem;
+  position: relative;
+
+  @media (max-width: 600px) {
+    padding: 4.375rem 1rem 0 1rem;
+  }
+`;
+
+export const Form = styled.form`
+  margin-top: 1.75rem;
+  padding: 0rem 5rem;
+`;
+
+export const FormFieldsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.625rem;
+`;
+
+export const Textarea = styled.textarea<{ isError: boolean }>`
+  ${({ theme }) => theme.typo.body1};
+  height: 29.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.625rem;
+  border: 1px solid ${({ theme }) => theme.color.grey[100]};
+  resize: none;
+  border: 0.0625rem solid
+    ${({ theme, isError }) =>
+      isError ? theme.color.error : theme.color.grey[100]};
+  color: ${({ theme }) => theme.color.black};
+
+  ::placeholder {
+    ${({ theme }) => theme.typo.body1};
+    color: ${({ theme }) => theme.color.grey[400]};
+  }
+
+  :focus {
+    outline: none;
+    border: 0.0625rem solid
+      ${({ theme, isError }) =>
+        isError ? theme.color.error : theme.color.skyBlue[400]};
+  }
+`;
+
+export const NextButton = styled.button`
+  ${({ theme }) => theme.typo.button};
+  width: 100%;
+  height: 2.75rem;
+  border-radius: 0.625rem;
+  background: ${({ theme }) => theme.color.skyBlue[400]};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: ${({ theme }) => theme.color.white};
+  margin-top: 0.875rem;
+`;

--- a/src/pageContainer/index.ts
+++ b/src/pageContainer/index.ts
@@ -1,3 +1,4 @@
+export { default as CommunityWrite } from './community/write';
 export { default as Gwangya } from './community/gwangya';
 export { default as MenteeRegister } from './register/mentee';
 export { default as MentorRegister } from './register/mentor';


### PR DESCRIPTION
## 개요 💡

커뮤니티 글 작성 페이지 퍼블리싱을 진행했습니다.

## 작업내용 ⌨️

<img width="400" alt="스크린샷 2024-03-27 17 14 50" src="https://github.com/themoment-team/GSM-Networking-front/assets/80103328/adf05b1c-6cd8-4b02-8a5f-4f85c086dcb1">

- 커뮤니티의 글 작성 페이지를 퍼블리싱 했습니다.
  - select가 동작하지 않는 이유는 `SelectFormItem` 컴포넌트가 react-hook-form 과의 연동에 최적화되게끔 설계하여 단순 마크업만 작성된 지금은 원활하게 동작되지 않습니다.
  - 해당 `SelectFormItem` 컴포넌트 사용법 보충을 위해 설명(448957f3b2eec50fad387045ab4c5779f955b66c)을 추가했습니다.