### PR TITLE
Add mentee redirect exception

### DIFF
--- a/src/app/register/mentee/page.tsx
+++ b/src/app/register/mentee/page.tsx
@@ -1,5 +1,14 @@
+import { redirect } from 'next/navigation';
+
+import { getMyMenteeInfo } from '@/apis';
 import { MenteeRegister } from '@/pageContainer';
 
-const Mentee = () => <MenteeRegister />;
+const Mentee = async () => {
+  const myInfo = await getMyMenteeInfo('/');
+
+  if (myInfo) return redirect(`/`);
+
+  return <MenteeRegister />;
+};
 
 export default Mentee;


### PR DESCRIPTION
## 개요 💡

몇분 전 서비스에 접속 시 갑자기 멘티 정보 등록 페이지로 리다이렉트 되었다는 제보를 받았습니다.
메인 페이지 접속 시 멘티 정보 등록 페이지로 리다이렉트 될 수 있는 경우는 멘티 정보 API 요청 시 404가 반환되는 경우 밖에는 없습니다.

제가 해당 환경에서 테스트 해본 결과 같은 문제가 나타나지 않아 일시적 네트워크 이슈로 판단하였습니다.
그럼에도 이미 멘티 정보가 등록되어있는 사용자가 멘티 정보 등록 페이지에 접속할 여지가 있다는 것은 user flow에 어긋나기 때문에 이에 대한 예외 처리를 했습니다.
