### PR TITLE
Resolve build error

### DIFF
--- a/src/app/community/board/page.tsx
+++ b/src/app/community/board/page.tsx
@@ -3,10 +3,9 @@ import { redirect } from 'next/navigation';
 
 import { boardUrl } from '@/libs';
 import { Board } from '@/pageContainer';
-import type { BoardInfo } from '@/types';
+import type { BoardInfoType } from '@/types';
 
 import type { Metadata } from 'next';
-
 
 export const metadata: Metadata = {
   title: '게시판',
@@ -19,7 +18,7 @@ const BoardPage = async () => {
   return <Board initialData={[...boardList]} />;
 };
 
-const getBoardList = async (): Promise<BoardInfo[]> => {
+const getBoardList = async (): Promise<BoardInfoType[]> => {
   const accessToken = cookies().get('accessToken')?.value;
 
   if (!accessToken) return redirect('/auth/refresh');
@@ -36,12 +35,11 @@ const getBoardList = async (): Promise<BoardInfo[]> => {
     return redirect('/auth/refresh');
   }
 
-
   if (!response.ok) {
     return redirect('/auth/signin');
   }
 
-  const boardList: BoardInfo[] = await response.json();
+  const boardList: BoardInfoType[] = await response.json();
 
   return boardList;
 };

--- a/src/components/BoardCard/index.tsx
+++ b/src/components/BoardCard/index.tsx
@@ -4,12 +4,12 @@ import React, { forwardRef } from 'react';
 
 import * as S from './style';
 
-import type { BoardInfo } from '@/types';
+import type { BoardInfoType } from '@/types';
 import { ReverseCategoryType } from '@/types';
 import { parseDateString } from '@/utils';
 
 // eslint-disable-next-line react/display-name
-const BoardCard = forwardRef<HTMLDivElement, BoardInfo>(
+const BoardCard = forwardRef<HTMLDivElement, BoardInfoType>(
   ({ id, createdAt, title, authorName, boardCategory }, ref) => {
     const { monthDay, time } = parseDateString(createdAt);
 

--- a/src/components/BoardCard/index.tsx
+++ b/src/components/BoardCard/index.tsx
@@ -8,7 +8,6 @@ import type { BoardInfoType } from '@/types';
 import { ReverseCategoryType } from '@/types';
 import { parseDateString } from '@/utils';
 
-// eslint-disable-next-line react/display-name
 const BoardCard = forwardRef<HTMLDivElement, BoardInfoType>(
   ({ id, createdAt, title, authorName, boardCategory }, ref) => {
     const { monthDay, time } = parseDateString(createdAt);
@@ -32,4 +31,7 @@ const BoardCard = forwardRef<HTMLDivElement, BoardInfoType>(
     );
   }
 );
+
+BoardCard.displayName = 'BoardCard';
+
 export default BoardCard;

--- a/src/hooks/api/board/useGetBoardList.ts
+++ b/src/hooks/api/board/useGetBoardList.ts
@@ -1,13 +1,13 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { get, boardQueryKeys, boardUrl } from '@/libs';
-import type { BoardInfo } from '@/types';
+import type { BoardInfoType } from '@/types';
 
-export const useGetBoardList = (initialData?: BoardInfo[]) =>
+export const useGetBoardList = (initialData?: BoardInfoType[]) =>
   useInfiniteQuery({
     queryKey: boardQueryKeys.getBoardList(),
     queryFn: async ({ pageParam }) =>
-      get<BoardInfo[]>(`${boardUrl.getBoardList(pageParam)}`),
+      get<BoardInfoType[]>(`${boardUrl.getBoardList(pageParam)}`),
     initialPageParam: 0,
     getPreviousPageParam: (firstPage) => firstPage[0]?.id,
     getNextPageParam: (lastPage) => lastPage[lastPage.length - 1]?.id,

--- a/src/pageContainer/community/board/index.tsx
+++ b/src/pageContainer/community/board/index.tsx
@@ -8,16 +8,15 @@ import { Header, CommunityButton, WriteButton } from '@/components';
 import { BoardCard } from '@/components';
 import { useIntersectionObserver } from '@/hooks';
 import { useGetBoardList } from '@/hooks';
-import type { BoardInfo } from '@/types';
+import type { BoardInfoType } from '@/types';
 
 interface Props {
-  initialData: BoardInfo[];
+  initialData: BoardInfoType[];
 }
 
 const Board: React.FC<Props> = ({ initialData }) => {
   const postListRef = useRef<HTMLDivElement>(null);
   const loadMoreTriggerRef = useRef<HTMLDivElement>(null);
-
 
   const { data, fetchNextPage, isFetchingNextPage, hasNextPage } =
     useGetBoardList(initialData);
@@ -49,12 +48,7 @@ const Board: React.FC<Props> = ({ initialData }) => {
         <S.BoardCardWrapper>
           <S.BoardCardList ref={postListRef} isFetching={isFetchingNextPage}>
             {data?.pages.map((page) =>
-              page.map((card) => (
-                <BoardCard
-                  key={card.id}
-                  {...card}
-                />
-              ))
+              page.map((card) => <BoardCard key={card.id} {...card} />)
             )}
             {!isFetchingNextPage && hasNextPage && (
               <S.LoadMoreTrigger ref={loadMoreTriggerRef} />

--- a/src/types/boardInfo.ts
+++ b/src/types/boardInfo.ts
@@ -1,16 +1,9 @@
+import type { ReverseCategoryType } from '@/types';
+
 export interface BoardInfoType {
   id: number;
   title: string;
-  boardCategory:
-    | 'TEACHER'
-    | 'NOTICE'
-    | 'QnA'
-    | 'CHAT'
-    | 'SHARE'
-    | 'STUDY'
-    | 'HOSTEL'
-    | 'MEET'
-    | 'SPORT';
+  boardCategory: keyof typeof ReverseCategoryType;
   authorName: string;
   createdAt: string;
 }

--- a/src/types/boardInfo.ts
+++ b/src/types/boardInfo.ts
@@ -1,4 +1,4 @@
-export interface BoardInfo {
+export interface BoardInfoType {
   id: number;
   title: string;
   boardCategory:


### PR DESCRIPTION
## 개요 💡

현재 [develop](1fe4952cc574fc73c2cd6d44cbd6504217429580) 에서 발생하는 build 에러를 해결했습니다.

## 작업내용 ⌨️

1. type 네이밍 컨벤션에 맞게 `BoardInfo` => `BoardInfoType` 네이밍 수정을 했습니다.
2. `BoardInfoType.boardCategory`에 직접 선언된 union type과 ReverseCategoryType 이 일치하지 않아 빌드 에러가 발생했습니다.
    - 일관성을 위해 `ReverseCategoryType`을 기반으로 타입을 변경했습니다.
      <img width="600" alt="스크린샷 2024-04-08 19 24 08" src="https://github.com/themoment-team/GSM-Networking-front/assets/80103328/cf4064cb-b79a-43a1-b5dc-4c022e05a3f6">

## 기타 

- BoardCard.displayName 추가