### PR TITLE
Update boardCard linkArea

### DIFF
--- a/src/components/BoardCard/index.tsx
+++ b/src/components/BoardCard/index.tsx
@@ -13,8 +13,8 @@ const BoardCard = forwardRef<HTMLDivElement, BoardInfoType>(
     const { monthDay, time } = parseDateString(createdAt);
 
     return (
-      <S.BoardCard ref={ref}>
-        <S.ContentBox href={`/community/board/${id}`}>
+      <S.ContentBox href={`/community/board/${id}`}>
+        <S.BoardCard ref={ref}>
           <S.ContentHeader>
             <S.HeaderTitle>
               <S.Name>{authorName}</S.Name>
@@ -26,8 +26,8 @@ const BoardCard = forwardRef<HTMLDivElement, BoardInfoType>(
             <S.Tag>#{ReverseCategoryType[boardCategory]}</S.Tag>
           </S.ContentHeader>
           <S.Content>{title}</S.Content>
-        </S.ContentBox>
-      </S.BoardCard>
+        </S.BoardCard>
+      </S.ContentBox>
     );
   }
 );

--- a/src/components/BoardCard/index.tsx
+++ b/src/components/BoardCard/index.tsx
@@ -1,37 +1,37 @@
 'use client';
 
-import React, { forwardRef } from 'react';
-
 import * as S from './style';
 
 import type { BoardInfoType } from '@/types';
 import { ReverseCategoryType } from '@/types';
 import { parseDateString } from '@/utils';
 
-const BoardCard = forwardRef<HTMLDivElement, BoardInfoType>(
-  ({ id, createdAt, title, authorName, boardCategory }, ref) => {
-    const { monthDay, time } = parseDateString(createdAt);
+const BoardCard: React.FC<BoardInfoType> = ({
+  id,
+  createdAt,
+  title,
+  authorName,
+  boardCategory,
+}) => {
+  const { monthDay, time } = parseDateString(createdAt);
 
-    return (
-      <S.ContentBox href={`/community/board/${id}`}>
-        <S.BoardCard ref={ref}>
-          <S.ContentHeader>
-            <S.HeaderTitle>
-              <S.Name>{authorName}</S.Name>
-              <S.DateAndTime>
-                <S.Date>{monthDay}</S.Date>
-                <S.Time>{time}</S.Time>
-              </S.DateAndTime>
-            </S.HeaderTitle>
-            <S.Tag>#{ReverseCategoryType[boardCategory]}</S.Tag>
-          </S.ContentHeader>
-          <S.Content>{title}</S.Content>
-        </S.BoardCard>
-      </S.ContentBox>
-    );
-  }
-);
-
-BoardCard.displayName = 'BoardCard';
+  return (
+    <S.ContentBox href={`/community/board/${id}`}>
+      <S.BoardCard>
+        <S.ContentHeader>
+          <S.HeaderTitle>
+            <S.Name>{authorName}</S.Name>
+            <S.DateAndTime>
+              <S.Date>{monthDay}</S.Date>
+              <S.Time>{time}</S.Time>
+            </S.DateAndTime>
+          </S.HeaderTitle>
+          <S.Tag>#{ReverseCategoryType[boardCategory]}</S.Tag>
+        </S.ContentHeader>
+        <S.Content>{title}</S.Content>
+      </S.BoardCard>
+    </S.ContentBox>
+  );
+};
 
 export default BoardCard;

--- a/src/pageContainer/community/board/index.tsx
+++ b/src/pageContainer/community/board/index.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import React, { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState } from 'react';
 
 import * as S from './style';
-
 
 import { FilterNotFoundIcon } from '@/assets';
 import {


### PR DESCRIPTION
## 개요 💡

> boardCard의 클릭 범위를 업데이트 했습니다.

## 작업내용 ⌨️
padding까지 포함되도록 카드의 전체 너비로 클릭 범위를 적용시켰습니다.

<img width="328" alt="image" src="https://github.com/themoment-team/GSM-Networking-front/assets/106712562/12ee6065-ab65-413c-a00f-ff27f7a46b9f">


