### PR TITLE
Add max length

### DIFF
--- a/src/pageContainer/community/write/index.tsx
+++ b/src/pageContainer/community/write/index.tsx
@@ -89,6 +89,7 @@ const CommunityWrite = () => {
               inputTitle='제목'
               placeholder='50자 이내'
               errorMessage={errors.title?.message}
+              maxLength={50}
             />
             <FormItemWrapper
               title='내용'
@@ -98,6 +99,7 @@ const CommunityWrite = () => {
                 {...register('content')}
                 placeholder='1000자 이내'
                 isError={!!errors.content?.message}
+                maxLength={1000}
               />
             </FormItemWrapper>
           </S.FormFieldsWrapper>


### PR DESCRIPTION
## 개요 💡

게시물 작성에서 최대 글자수 제한을 추가했습니다.

## 작업내용 ⌨️

게시물 작성에서 최대 글자수 제한을 추가했습니다.

기존에는 1000자 이상 작성이 가능하여 애초에 1000자 이상 작성을 막았습니다.
