### PR TITLE
[Hotfix] Update redirect that after login

### DIFF
--- a/src/apis/board/comment/getCommentDetail.ts
+++ b/src/apis/board/comment/getCommentDetail.ts
@@ -13,11 +13,16 @@ const AUTH_REFRESH_PATH = '/auth/refresh' as const;
  */
 export const getCommentDetail = async (
   redirectUrl: string,
-  commentId: string
+  commentId: string,
+  boardId: string
 ): Promise<CommentType | null> => {
   const accessToken = cookies().get('accessToken')?.value;
 
-  if (!accessToken) return redirect(`/auth/refresh?redirect=${redirectUrl}`);
+  if (!accessToken) {
+    return redirect(
+      `/auth/refresh?redirect=${redirectUrl}/${boardId}/${commentId}`
+    );
+  }
 
   const response = await fetch(
     new URL(
@@ -41,7 +46,9 @@ export const getCommentDetail = async (
   }
 
   if (isUnauthorized) {
-    return redirect(`${AUTH_REFRESH_PATH}?redirect=${redirectUrl}`);
+    return redirect(
+      `${AUTH_REFRESH_PATH}?redirect=${redirectUrl}/${boardId}/${commentId}}`
+    );
   }
 
   if (!response.ok) {

--- a/src/apis/board/getBoardDetail.ts
+++ b/src/apis/board/getBoardDetail.ts
@@ -17,7 +17,8 @@ export const getBoardDetail = async (
 ): Promise<BoardType | null> => {
   const accessToken = cookies().get('accessToken')?.value;
 
-  if (!accessToken) return redirect(`/auth/refresh?redirect=${redirectUrl}`);
+  if (!accessToken)
+    return redirect(`/auth/refresh?redirect=${redirectUrl}/${boardId}`);
 
   const response = await fetch(
     new URL(`/api/v1${boardUrl.getBoardDetail(boardId)}`, process.env.BASE_URL),
@@ -38,7 +39,7 @@ export const getBoardDetail = async (
   }
 
   if (isUnauthorized) {
-    return redirect(`${AUTH_REFRESH_PATH}?redirect=${redirectUrl}`);
+    return redirect(`${AUTH_REFRESH_PATH}?redirect=${redirectUrl}/${boardId}`);
   }
 
   if (!response.ok) {

--- a/src/app/auth/refresh/route.ts
+++ b/src/app/auth/refresh/route.ts
@@ -24,6 +24,8 @@ export async function GET(request: NextRequest) {
 
   const cookieStore = cookies();
 
+  cookies().set('redirect', redirectPath);
+
   const refreshToken = cookieStore.get('refreshToken')?.value;
 
   try {

--- a/src/app/community/board/[boardId]/[commentId]/page.tsx
+++ b/src/app/community/board/[boardId]/[commentId]/page.tsx
@@ -1,14 +1,18 @@
 import { getCommentDetail } from '@/apis';
+import { BOARD_PATH } from '@/constants';
 import { AddComment } from '@/pageContainer';
 
 interface Params {
   params: {
     commentId: string;
+    boardId: string;
   };
 }
 
-const AddCommentPage: React.FC<Params> = async ({ params: { commentId } }) => {
-  const commentDetail = await getCommentDetail('/community/board', commentId);
+const AddCommentPage: React.FC<Params> = async ({
+  params: { commentId, boardId },
+}) => {
+  const commentDetail = await getCommentDetail(BOARD_PATH, commentId, boardId);
 
   return <AddComment initialData={commentDetail} commentId={commentId} />;
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,9 +39,15 @@ const getMentorList = async (): Promise<WorkerType[]> => {
   const accessToken = cookies().get('accessToken')?.value;
   const gwangyaToken = cookies().get('gwangyaToken')?.value;
 
+  const redirectPath = cookies().get('redirect')?.value;
+
   if (!accessToken) return redirect('/auth/refresh');
 
   if (!gwangyaToken) return redirect('/auth/refresh/gwangya?redirect=/');
+
+  if (redirectPath && redirectPath !== '/') {
+    return redirect(redirectPath);
+  }
 
   const response = await fetch(
     new URL(`/api/v1${mentorUrl.getMentorList()}`, process.env.BASE_URL),

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,6 +1,10 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useEffect } from 'react';
+
+import { useSearchParams } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 
 import { ThemeProvider } from '@emotion/react';
 
@@ -8,6 +12,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 
 import QueryClient from '@/app/queryClient';
 import { theme } from '@/styles';
+import { deleteCookie } from '@/utils';
 
 interface Props {
   children: React.ReactNode;
@@ -15,6 +20,13 @@ interface Props {
 
 const Providers: React.FC<Props> = ({ children }) => {
   const [queryClient] = useState(() => QueryClient);
+
+  const path = usePathname();
+  const params = useSearchParams();
+
+  useEffect(() => {
+    if (!path.includes('auth')) deleteCookie('redirect');
+  }, [path, params]);
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/utils/deleteCookie.ts
+++ b/src/utils/deleteCookie.ts
@@ -1,0 +1,5 @@
+const deleteCookie = (cookieName: string) => {
+  document.cookie =
+    cookieName + '=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+};
+export default deleteCookie;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export { default as UTCDate } from './UTCDate';
 export { default as careerValidation } from './careerValidation';
 export { default as deepCopy } from './deepCopy';
+export { default as deleteCookie } from './deleteCookie';
 export { default as extractCareer } from './extractCareer';
 export { default as extractSubstring } from './extractSubstring';
 export { default as formatTelNum } from './formatTelNum';


### PR DESCRIPTION
## 개요 💡

> 공유가 가능하도록 로그인 후 이전 페이지로 리다이렉트 할 수 있도록 했습니다.

## 작업내용 ⌨️
요구사항

1.token이 만료된 유저가 /abc path로 접속
2.token 만료 확인 후 refresh -> /auth/signin이동
3.로그인 시 구글 OAuth 페이지로 이동 후 / 루트 페이지로 리다이렉트 (서버 측에서 구현)
4. 이전에 접속한 페이지 ex) /abc가 있을 경우 리다이렉트

4번 기능을 구현하였습니다.

- board와 board comment에서 redirect url을 업데이트했습니다.
- /auth/refresh에서 login 이전 path를 쿠키에 저장합니다. -> 로그인 후 리다이렉트 시 쿠키에 값이 있으면 이동합니다. -> 쿠키를 제거함과 동시에 리다이렉트가 불가능하여 클라이언트 측에서 쿠키를 제거하는 로직을 Provider에 추가했습니다.
아래는 관련 이슈입니다.
https://github.com/vercel/next.js/discussions/48434
