### PR TITLE
[Hotfix] Profile Update Resolve

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -37,6 +37,7 @@ const Header: React.FC<Props> = ({
   };
 
   useEffect(() => {
+    setProfileUrl('');
     if (mentorInfo?.profileUrl) setProfileUrl(mentorInfo.profileUrl);
     if (menteeInfo?.profileUrl) setProfileUrl(menteeInfo.profileUrl);
     if (mentorInfo?.defaultImgNumber)


### PR DESCRIPTION
## 개요 💡

이미지로 프로필을 변경후 기본 프로필 이미지로 변경시 header 프로필이 변경 안되는 문제를 해결하였습니다

https://github.com/themoment-team/GSM-Networking-front/assets/128475660/3322440b-5a43-47e1-b293-9359df2c13a3


## 작업내용 ⌨️

- useEffect안에 setProfileUrl 추가
