### PR TITLE
fix: 잘못된 테스트 케이스 수정

### DIFF
--- a/src/utils/__test__/dateFormat.test.ts
+++ b/src/utils/__test__/dateFormat.test.ts
@@ -6,14 +6,14 @@ describe('parseDateString', () => {
     const parsedDate = parseDateString(dateString);
 
     expect(parsedDate.monthDay).toBe('2월 12일');
-    expect(parsedDate.time).toBe('오전 9:00');
+    expect(parsedDate.time).toBe('오후 6:00');
   });
 
   test('주어진 다른 날짜 문자열을 올바르게 파싱합니다.', () => {
     const dateString = '2024-03-21T15:30:00.000Z';
     const parsedDate = parseDateString(dateString);
 
-    expect(parsedDate.monthDay).toBe('3월 21일');
-    expect(parsedDate.time).toBe('오후 12:30');
+    expect(parsedDate.monthDay).toBe('3월 22일');
+    expect(parsedDate.time).toBe('오전 12:30');
   });
 });

--- a/src/utils/__test__/dateFormat.test.ts
+++ b/src/utils/__test__/dateFormat.test.ts
@@ -2,18 +2,18 @@ import { parseDateString } from '@/utils';
 
 describe('parseDateString', () => {
   test('주어진 날짜 문자열을 올바르게 파싱합니다.', () => {
-    const dateString = '2005-02-12T09:00:00.000Z';
-    const parsedDate = parseDateString(dateString);
+    const date = new Date(Date.UTC(2005, 1, 12, 9)).toISOString();
+    const parsedDate = parseDateString(date);
 
-    expect(parsedDate.monthDay).toBe('2월 12일');
-    expect(parsedDate.time).toBe('오후 6:00');
+    const expected = { monthDay: '2월 12일', time: '오후 6:00' };
+    expect(parsedDate).toEqual(expected);
   });
 
   test('주어진 다른 날짜 문자열을 올바르게 파싱합니다.', () => {
-    const dateString = '2024-03-21T15:30:00.000Z';
-    const parsedDate = parseDateString(dateString);
+    const date = new Date(Date.UTC(2024, 2, 21, 15, 30)).toISOString();
+    const parsedDate = parseDateString(date);
 
-    expect(parsedDate.monthDay).toBe('3월 22일');
-    expect(parsedDate.time).toBe('오전 12:30');
+    const expected = { monthDay: '3월 22일', time: '오전 12:30' };
+    expect(parsedDate).toEqual(expected);
   });
 });


### PR DESCRIPTION
## 개요 💡

> `pnpm test` 커멘트 실행시 fail 발생

## 작업내용 ⌨️

> `pnpm test` 실행시 예상되는 값과 받은 값이 달라서 fail이 발생 되는것 같아
테스트코드의 문제인지, 아니면 호출되는 `parseDateString`함수의 문제인지 확인했습니다
`2024-03-21T15:30:00.000Z` 위와 같은 시간의 경우 UTC기준 2024년 3월 21일 오후 3시 30분
이지만 한국시간이 되기 위해 +9시간을 해야하지 2024년 3월 22일 오전 12시 30분입니다
따라서 테스트코드가 잘못되었다 판단
수정후 PR합니다