### PR TITLE
Hotfix: 맨토 재직기간 오류 수정

### DIFF
--- a/src/components/CareerRegistrationBox/index.tsx
+++ b/src/components/CareerRegistrationBox/index.tsx
@@ -147,14 +147,22 @@ const CareerRegistrationBox: React.FC<Props> = ({
   };
 
   // 시작 연도보다 과거의 연도를 선택할 수 없도록 리턴합니다.
-  const getYearArray = (selectedYear: string) => {
+  const getYearArray = (selectedStartYear: string, selectedEndYear: string) => {
     const date = new Date();
     const currentYear = date.getFullYear();
 
-    return YEAR_ARRAY.filter(
+    const availableYearArray = YEAR_ARRAY.filter(
       (year) =>
-        Number(year) >= Number(selectedYear) && Number(year) <= currentYear
+        Number(year) >= Number(selectedStartYear) && Number(year) <= currentYear
     );
+
+    if (
+      availableYearArray.length === 1 ||
+      availableYearArray[0] > Number(selectedEndYear)
+    ) {
+      endYear.value = availableYearArray[0];
+    }
+    return availableYearArray;
   };
 
   return (
@@ -228,7 +236,10 @@ const CareerRegistrationBox: React.FC<Props> = ({
               <Select
                 ref={endYearRef}
                 value={endYear.value}
-                options={getYearArray(String(startYear.value))}
+                options={getYearArray(
+                  String(startYear.value),
+                  String(endYear.value)
+                )}
                 disabled={isWorking.value}
                 defaultValue='년'
                 onChange={(e) => handlePeriodChange(e, 'endYear')}

--- a/src/components/CareerRegistrationBox/index.tsx
+++ b/src/components/CareerRegistrationBox/index.tsx
@@ -146,6 +146,17 @@ const CareerRegistrationBox: React.FC<Props> = ({
     return [...MONTH_ARRAY];
   };
 
+  // 시작 연도보다 과거의 연도를 선택할 수 없도록 리턴합니다.
+  const getYearArray = (selectedYear: string) => {
+    const date = new Date();
+    const currentYear = date.getFullYear();
+
+    return YEAR_ARRAY.filter(
+      (year) =>
+        Number(year) >= Number(selectedYear) && Number(year) <= currentYear
+    );
+  };
+
   return (
     <S.CompanyBox>
       <S.TitleBox>
@@ -217,7 +228,7 @@ const CareerRegistrationBox: React.FC<Props> = ({
               <Select
                 ref={endYearRef}
                 value={endYear.value}
-                options={[...YEAR_ARRAY]}
+                options={getYearArray(String(startYear.value))}
                 disabled={isWorking.value}
                 defaultValue='년'
                 onChange={(e) => handlePeriodChange(e, 'endYear')}

--- a/src/pageContainer/register/mentor/index.tsx
+++ b/src/pageContainer/register/mentor/index.tsx
@@ -138,13 +138,13 @@ const MentorRegister: React.FC<Props> = ({
           companyUrl: { value: career.companyUrl ?? '', errorMessage: null },
           position: { value: career.position, errorMessage: null },
           startYear: { value: startDate.getFullYear(), errorMessage: null },
-          startMonth: { value: startDate.getMonth(), errorMessage: null },
+          startMonth: { value: startDate.getMonth() + 1, errorMessage: null },
           endYear: {
             value: endDate ? endDate.getFullYear() : '년',
             errorMessage: null,
           },
           endMonth: {
-            value: endDate ? endDate.getMonth() : '월',
+            value: endDate ? endDate.getMonth() + 1 : '월',
             errorMessage: null,
           },
           isWorking: { value: career.isWorking, errorMessage: null },


### PR DESCRIPTION
## 개요 💡

> 1. 멘토 재직기간에서 startMonth가 1씩 감소하여 저장되는 현상
> 2. 시작연도보다 과거연도를 끝연도로 설정가능한 현상

## 작업내용 ⌨️

> 1번 현상은 getMonth()을 불러올때 + 1을 하여 해결
2번 현상은 startYear보다 이전 연도를 제외한 배열을 endYear의 옵션으로 리턴하여 해결

